### PR TITLE
Issue #33 - set keyboard focus to text field in the batch tag dialog

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/TagImagesDialog.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/TagImagesDialog.java
@@ -23,6 +23,7 @@ import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Cursor;
@@ -31,6 +32,8 @@ import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
 import java.awt.font.TextAttribute;
 import java.io.File;
 import java.util.List;
@@ -70,6 +73,14 @@ public class TagImagesDialog extends JDialog {
         setLayout(new BorderLayout());
         add(buildFormPanel(), BorderLayout.CENTER);
         add(buildButtonPanel(), BorderLayout.SOUTH);
+
+        // Ensure the text area gets focus when the dialog is opened.
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowOpened(WindowEvent e) {
+                textField.getTextArea().requestFocusInWindow();
+            }
+        });
     }
 
     private void applyTags() {

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/TagImagesDialog.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/TagImagesDialog.java
@@ -23,7 +23,6 @@ import javax.swing.JButton;
 import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.SwingUtilities;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Cursor;

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
@@ -2,7 +2,7 @@ ext-iv-ice Release Notes
 Author: Steve Corbett
 
 Version 2.4.0 [TODO release date here]
-  TODO release notes here
+  #33 - Auto-set keyboard focus to text field in batch tag dialog
 
 Version 2.3.0 [2025-12-07]
   #30 - Fix bug with tag preview panel not clearing properly


### PR DESCRIPTION
This PR addresses Issue #33 by setting the initial keyboard focus on the batch tag dialog into the text field. This makes it slightly more convenient users to bring the dialog up and immediately start typing tags, instead of having to manually focus the text field first.