### PR TITLE
Issue #40 - upgrade to ImageViewer 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ But there are actually quite a few additional features now available in the appl
 
 ### Tagging a single image
 
-The first thing we can do is hit Ctrl+G to bring up the tag edit dialog for the currently selected image:
+The first thing we can do is hit Ctrl+G (or whatever shortcut you have configured in the application settings dialog)
+to bring up the tag edit dialog for the currently selected image:
 
 ![Tag edit dialog](docs/screenshot02.jpg)
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ remove the extension, revisit the extension manager dialog, select "ICE" in the 
 ### Option 2: Manual download
 
 You can manually download the extension jar: 
-[ext-iv-ice-2.4.0.jar](https://www.corbett.ca/apps/ImageViewer/extensions/2.4/ext-iv-ice-2.4.0.jar)
+[ext-iv-ice-3.0.0.jar](https://www.corbett.ca/apps/ImageViewer/extensions/3.0/ext-iv-ice-3.0.0.jar)
 
 Save it to your ~/.ImageViewer/extensions directory and restart the application.
 
@@ -136,7 +136,7 @@ mvn package
 
 # Copy the result to the extensions directory:
 cd target
-cp ext-iv-ice-2.4.0.jar ~/.ImageViewer/extensions
+cp ext-iv-ice-3.0.0.jar ~/.ImageViewer/extensions
 ```
 
 ## License

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ca.corbett</groupId>
     <artifactId>ext-iv-ice</artifactId>
-    <version>2.4.0</version>
+    <version>3.0.0-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>ca.corbett</groupId>
             <artifactId>imageviewer</artifactId>
-            <version>2.4</version>
+            <version>3.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
@@ -216,7 +216,8 @@ public class IceExtension extends ImageViewerExtension {
             actions.add(TagSingleImageAction.getInstance());
             actions.add(new TagMultipleImagesAction());
 
-            if (browseMode == MainWindow.BrowseMode.FILE_SYSTEM) {
+            // Only add scan actions if the tag index is enabled:
+            if (browseMode == MainWindow.BrowseMode.FILE_SYSTEM && TagIndex.isEnabled()) {
                 actions.add(new ScanDirAction("Tag scan: current directory", false));
                 actions.add(new ScanDirAction("Tag scan: current directory recursively", true));
             }

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
@@ -1,12 +1,15 @@
 package ca.corbett.imageviewer.extensions.ice;
 
 import ca.corbett.extensions.AppExtensionInfo;
+import ca.corbett.extras.EnhancedAction;
 import ca.corbett.extras.LookAndFeelManager;
 import ca.corbett.extras.RedispatchingMouseAdapter;
+import ca.corbett.extras.io.KeyStrokeManager;
 import ca.corbett.extras.properties.AbstractProperty;
 import ca.corbett.extras.properties.BooleanProperty;
 import ca.corbett.extras.properties.ComboProperty;
 import ca.corbett.extras.properties.IntegerProperty;
+import ca.corbett.extras.properties.KeyStrokeProperty;
 import ca.corbett.extras.properties.PropertiesManager;
 import ca.corbett.extras.properties.ShortTextProperty;
 import ca.corbett.imageviewer.AppConfig;
@@ -14,10 +17,10 @@ import ca.corbett.imageviewer.ImageOperation;
 import ca.corbett.imageviewer.extensions.ImageViewerExtension;
 import ca.corbett.imageviewer.extensions.ice.actions.RandomImageSetAction;
 import ca.corbett.imageviewer.extensions.ice.actions.ScanDirAction;
+import ca.corbett.imageviewer.extensions.ice.actions.SearchAction;
 import ca.corbett.imageviewer.extensions.ice.actions.TagDirStatsAction;
 import ca.corbett.imageviewer.extensions.ice.actions.TagMultipleImagesAction;
 import ca.corbett.imageviewer.extensions.ice.actions.TagSingleImageAction;
-import ca.corbett.imageviewer.extensions.ice.actions.SearchAction;
 import ca.corbett.imageviewer.extensions.ice.actions.TagStatsAction;
 import ca.corbett.imageviewer.extensions.ice.ui.QuickTagPanel;
 import ca.corbett.imageviewer.extensions.ice.ui.TagPreviewPanel;
@@ -28,17 +31,12 @@ import org.apache.commons.io.FilenameUtils;
 
 import javax.swing.JComponent;
 import javax.swing.JLabel;
-import javax.swing.JMenu;
-import javax.swing.JMenuItem;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
-import javax.swing.KeyStroke;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Cursor;
 import java.awt.FlowLayout;
-import java.awt.event.InputEvent;
-import java.awt.event.KeyEvent;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -82,6 +80,7 @@ public class IceExtension extends ImageViewerExtension {
     public static final String quickTagPanelWidthProp = "ICE.General.quickTagPanelWidth";
     public static final String fontSizeProp = "Thumbnails.Companion files.linkFontSize";
     public static final String quickTagSourceProp = "Hidden.quickTags.source";
+    public static final String quickTagShortcutProp = AppConfig.KEYSTROKE_PREFIX + "ICE.quickTagPanel";
 
     private final List<TagPreviewPanel> tagPreviewPanels = new ArrayList<>();
     private final List<QuickTagPanel> quickTagPanels = new ArrayList<>();
@@ -117,6 +116,10 @@ public class IceExtension extends ImageViewerExtension {
         list.add(new IntegerProperty(fontSizeProp, "Hyperlink font size", 10, 8, 16, 1));
         list.add(new BooleanProperty(TagIndex.PROP_NAME, "Enable tag index for faster searches", true));
         list.add(new ShortTextProperty(quickTagSourceProp, "quickTagsSource", QuickTagPanel.DEFAULT_SOURCE_NAME).setExposed(false));
+        list.add(new KeyStrokeProperty(quickTagShortcutProp, "Image tag dialog:",
+                                       KeyStrokeManager.parseKeyStroke("Ctrl+G"),
+                                       TagSingleImageAction.getInstance())
+                         .setAllowBlank(true));
         return list;
     }
 
@@ -196,58 +199,37 @@ public class IceExtension extends ImageViewerExtension {
     }
 
     /**
-     * Returns the ICE top-level menu which is to be added to the application's main menu bar.
+     * We have a top-level "ICE" menu with various actions in it.
+     * This menu is presented in all browse modes.
      */
     @Override
-    public List<JMenu> getTopLevelMenus(MainWindow.BrowseMode browseMode) {
-        JMenu iceMenu = new JMenu("ICE");
-        iceMenu.setMnemonic(KeyEvent.VK_I);
-
-        JMenuItem searchItem = new JMenuItem(new SearchAction());
-        iceMenu.add(searchItem);
-
-        JMenuItem tagSingleImageItem = new JMenuItem(new TagSingleImageAction());
-        tagSingleImageItem.setMnemonic(KeyEvent.VK_G);
-        tagSingleImageItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_G, InputEvent.CTRL_DOWN_MASK));
-        iceMenu.add(tagSingleImageItem);
-
-        JMenuItem tagMultiImagesItem = new JMenuItem(new TagMultipleImagesAction("Tag images..."));
-        iceMenu.add(tagMultiImagesItem);
-
-        if (browseMode == MainWindow.BrowseMode.FILE_SYSTEM) {
-            if (TagIndex.isEnabled()) {
-                JMenuItem scanDirItem = new JMenuItem(new ScanDirAction("Tag scan: current directory", false));
-                iceMenu.add(scanDirItem);
-
-                JMenuItem scanDirItemRecursive = new JMenuItem(
-                        new ScanDirAction("Tag scan: current directory recursively", true));
-                iceMenu.add(scanDirItemRecursive);
-            }
-        }
-
-        iceMenu.add(new TagStatsAction());
-        if (browseMode == MainWindow.BrowseMode.FILE_SYSTEM) {
-            iceMenu.add(new JMenuItem(new TagDirStatsAction()));
-            iceMenu.add(new JMenuItem(new RandomImageSetAction()));
-        }
-
-        return List.of(iceMenu);
+    public List<String> getTopLevelMenus(MainWindow.BrowseMode browseMode) {
+        return List.of("ICE");
     }
 
-    /**
-     * I wanted to use ctrl+t for "tag" but it was already in use by the
-     * image transform extension (ctrl+t for "transform"). One day I'll
-     * make extension keyboard shortcuts user-configurable.
-     */
     @Override
-    public boolean handleKeyboardShortcut(KeyEvent e) {
-        if (e.getKeyCode() == KeyEvent.VK_G) {
-            if ((e.getModifiersEx() & InputEvent.CTRL_DOWN_MASK) > 0) {
-                new TagSingleImageAction().actionPerformed(null);
-                return true;
+    public List<EnhancedAction> getMenuActions(String topLevelMenu, MainWindow.BrowseMode browseMode) {
+        List<EnhancedAction> actions = new ArrayList<>();
+
+        if (topLevelMenu.equals("ICE")) {
+            actions.add(new SearchAction());
+            actions.add(TagSingleImageAction.getInstance());
+            actions.add(new TagMultipleImagesAction());
+
+            if (browseMode == MainWindow.BrowseMode.FILE_SYSTEM) {
+                actions.add(new ScanDirAction("Tag scan: current directory", false));
+                actions.add(new ScanDirAction("Tag scan: current directory recursively", true));
+            }
+
+            actions.add(new TagStatsAction());
+
+            if (browseMode == MainWindow.BrowseMode.FILE_SYSTEM) {
+                actions.add(new TagDirStatsAction());
+                actions.add(new RandomImageSetAction());
             }
         }
-        return false;
+
+        return actions;
     }
 
     /**

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/RandomImageSetAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/RandomImageSetAction.java
@@ -1,9 +1,9 @@
 package ca.corbett.imageviewer.extensions.ice.actions;
 
+import ca.corbett.extras.EnhancedAction;
 import ca.corbett.imageviewer.extensions.ice.ui.dialogs.RandomImageSetDialog;
 import ca.corbett.imageviewer.ui.MainWindow;
 
-import javax.swing.AbstractAction;
 import java.awt.event.ActionEvent;
 import java.io.File;
 
@@ -14,24 +14,26 @@ import java.io.File;
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  * @since 2.4.0
  */
-public class RandomImageSetAction extends AbstractAction {
+public class RandomImageSetAction extends EnhancedAction {
+
+    private static final String NAME = "Generate random image set...";
 
     public RandomImageSetAction() {
-        super("Generate random image set...");
+        super(NAME);
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
         File dir = MainWindow.getInstance().getCurrentDirectory();
         if (dir == null) {
-            MainWindow.getInstance().showMessageDialog("Random image set", "Nothing selected.");
+            MainWindow.getInstance().showMessageDialog(NAME, "Nothing selected.");
             return;
         }
 
         // Shouldn't be possible to launch this action in image set mode, because we only
         // add the menu item in file system mode, but let's be sure about it:
         if (MainWindow.getInstance().getBrowseMode() != MainWindow.BrowseMode.FILE_SYSTEM) {
-            MainWindow.getInstance().showMessageDialog("Random image set",
+            MainWindow.getInstance().showMessageDialog(NAME,
                                                        "Random image set generation is only available in file system browse mode.");
             return;
         }

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/ScanDirAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/ScanDirAction.java
@@ -1,16 +1,17 @@
 package ca.corbett.imageviewer.extensions.ice.actions;
 
+import ca.corbett.extras.EnhancedAction;
 import ca.corbett.extras.progress.MultiProgressAdapter;
 import ca.corbett.extras.progress.MultiProgressDialog;
 import ca.corbett.imageviewer.extensions.ice.TagIndex;
 import ca.corbett.imageviewer.extensions.ice.threads.ScanThread;
 import ca.corbett.imageviewer.ui.MainWindow;
 
-import javax.swing.AbstractAction;
+import javax.swing.SwingUtilities;
 import java.awt.event.ActionEvent;
 import java.io.File;
 
-public class ScanDirAction extends AbstractAction {
+public class ScanDirAction extends EnhancedAction {
 
     private final boolean isRecursive;
 
@@ -31,13 +32,16 @@ public class ScanDirAction extends AbstractAction {
         scanThread.addProgressListener(new MultiProgressAdapter() {
             @Override
             public void progressComplete() {
-                MainWindow.getInstance().showMessageDialog("Scan complete",
-                                                           "Tag scan complete. Entries added: "
-                                                                   + scanThread.getEntriesCreated()
-                                                                   + "; entries updated: "
-                                                                   + scanThread.getEntriesUpdated()
-                                                                   + "; entries skipped (unchanged): "
-                                                                   + scanThread.getEntriesSkippedBecauseUpToDate());
+                // This callback is not on the EDT, so we need to switch to it to show the dialog:
+                SwingUtilities.invokeLater(() -> {
+                    MainWindow.getInstance().showMessageDialog("Scan complete",
+                                                               "Tag scan complete. Entries added: "
+                                                                       + scanThread.getEntriesCreated()
+                                                                       + "; entries updated: "
+                                                                       + scanThread.getEntriesUpdated()
+                                                                       + "; entries skipped (unchanged): "
+                                                                       + scanThread.getEntriesSkippedBecauseUpToDate());
+                });
             }
         });
         new MultiProgressDialog(MainWindow.getInstance(), "Tag scan").runWorker(scanThread, true);

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/SearchAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/SearchAction.java
@@ -1,16 +1,21 @@
 package ca.corbett.imageviewer.extensions.ice.actions;
 
+import ca.corbett.extras.EnhancedAction;
 import ca.corbett.imageviewer.extensions.ice.ui.dialogs.SearchDialog;
-import ca.corbett.imageviewer.ui.MainWindow;
 
-import javax.swing.AbstractAction;
 import java.awt.event.ActionEvent;
-import java.io.File;
 
-public class SearchAction extends AbstractAction {
+/**
+ * An action to launch the SearchDialog, for searching images by tag.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class SearchAction extends EnhancedAction {
+
+    private static final String NAME = "Search...";
 
     public SearchAction() {
-        super("Search...");
+        super(NAME);
     }
 
     @Override

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/TagDirStatsAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/TagDirStatsAction.java
@@ -1,29 +1,37 @@
 package ca.corbett.imageviewer.extensions.ice.actions;
 
+import ca.corbett.extras.EnhancedAction;
 import ca.corbett.imageviewer.extensions.ice.ui.dialogs.TagDirStatsDialog;
 import ca.corbett.imageviewer.ui.MainWindow;
 
-import javax.swing.AbstractAction;
 import java.awt.event.ActionEvent;
 import java.io.File;
 
-public class TagDirStatsAction extends AbstractAction {
+/**
+ * An action to launch the TagDirStatsDialog for viewing tag statistics
+ * for the currently selected directory.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class TagDirStatsAction extends EnhancedAction {
+    private static final String NAME = "Tag directory statistics...";
+
     public TagDirStatsAction() {
-        super("Tag directory statistics...");
+        super(NAME);
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
         File dir = MainWindow.getInstance().getCurrentDirectory();
         if (dir == null) {
-            MainWindow.getInstance().showMessageDialog("Tag directory statistics", "Nothing selected.");
+            MainWindow.getInstance().showMessageDialog(NAME, "Nothing selected.");
             return;
         }
 
         // Shouldn't be possible to launch this action in image set mode, because we only
         // add the menu item in file system mode, but let's be sure about it:
         if (MainWindow.getInstance().getBrowseMode() != MainWindow.BrowseMode.FILE_SYSTEM) {
-            MainWindow.getInstance().showMessageDialog("Tag directory statistics",
+            MainWindow.getInstance().showMessageDialog(NAME,
                     "Tag directory statistics is only available in file system browse mode.");
             return;
         }

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/TagMultipleImagesAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/TagMultipleImagesAction.java
@@ -1,12 +1,18 @@
 package ca.corbett.imageviewer.extensions.ice.actions;
 
+import ca.corbett.extras.EnhancedAction;
 import ca.corbett.imageviewer.extensions.ice.ui.dialogs.TagImagesDialog;
 import ca.corbett.imageviewer.ui.MainWindow;
 
-import javax.swing.AbstractAction;
 import java.awt.event.ActionEvent;
 
-public class TagMultipleImagesAction extends AbstractAction {
+public class TagMultipleImagesAction extends EnhancedAction {
+
+    private static final String NAME = "Tag images...";
+
+    public TagMultipleImagesAction() {
+        this(NAME);
+    }
 
     public TagMultipleImagesAction(String name) {
         super(name);
@@ -16,15 +22,15 @@ public class TagMultipleImagesAction extends AbstractAction {
     public void actionPerformed(ActionEvent e) {
         if (MainWindow.getInstance().getBrowseMode() == MainWindow.BrowseMode.FILE_SYSTEM
             && MainWindow.getInstance().getCurrentDirectory() == null) {
-            MainWindow.getInstance().showMessageDialog("Tag images", "No directory selected.");
+            MainWindow.getInstance().showMessageDialog(NAME, "No directory selected.");
             return;
         }
         if (MainWindow.getInstance().getBrowseMode() == MainWindow.BrowseMode.IMAGE_SET
             && MainWindow.getInstance().getImageSetPanel().getSelectedImageSet().isEmpty()) {
-            MainWindow.getInstance().showMessageDialog("Tag images", "No image set selected.");
+            MainWindow.getInstance().showMessageDialog(NAME, "No image set selected.");
             return;
         }
 
-        new TagImagesDialog("Tag images").setVisible(true);
+        new TagImagesDialog(NAME).setVisible(true);
     }
 }

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/TagSingleImageAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/TagSingleImageAction.java
@@ -1,26 +1,43 @@
 package ca.corbett.imageviewer.extensions.ice.actions;
 
-import ca.corbett.imageviewer.extensions.ice.ui.dialogs.TagDialog;
+import ca.corbett.extras.EnhancedAction;
 import ca.corbett.imageviewer.extensions.ice.TagList;
+import ca.corbett.imageviewer.extensions.ice.ui.dialogs.TagDialog;
 import ca.corbett.imageviewer.ui.ImageInstance;
 import ca.corbett.imageviewer.ui.MainWindow;
 import org.apache.commons.io.FilenameUtils;
 
-import javax.swing.AbstractAction;
 import java.awt.event.ActionEvent;
 import java.io.File;
 
-public class TagSingleImageAction extends AbstractAction {
+/**
+ * An action to launch the TagDialog for the currently selected image.
+ * This one is singleton because it has an associated KeyStrokeProperty, and we want
+ * its accelerator to get updated properly if the user remaps the keyboard shortcut.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class TagSingleImageAction extends EnhancedAction {
 
-    public TagSingleImageAction() {
-        super("Edit image tags");
+    private static final String NAME = "Edit image tags";
+    private static TagSingleImageAction instance;
+
+    TagSingleImageAction() {
+        super(NAME);
+    }
+
+    public static TagSingleImageAction getInstance() {
+        if (instance == null) {
+            instance = new TagSingleImageAction();
+        }
+        return instance;
     }
 
     @Override
     public void actionPerformed(ActionEvent e) {
         ImageInstance currentImage = MainWindow.getInstance().getSelectedImage();
         if (currentImage.isEmpty()) {
-            MainWindow.getInstance().showMessageDialog("Edit image tags", "Nothing selected.");
+            MainWindow.getInstance().showMessageDialog(NAME, "Nothing selected.");
             return;
         }
 

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/TagSingleImageAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/TagSingleImageAction.java
@@ -22,7 +22,7 @@ public class TagSingleImageAction extends EnhancedAction {
     private static final String NAME = "Edit image tags";
     private static TagSingleImageAction instance;
 
-    TagSingleImageAction() {
+    private TagSingleImageAction() {
         super(NAME);
     }
 

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/TagStatsAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/TagStatsAction.java
@@ -1,14 +1,21 @@
 package ca.corbett.imageviewer.extensions.ice.actions;
 
+import ca.corbett.extras.EnhancedAction;
 import ca.corbett.imageviewer.extensions.ice.ui.dialogs.TagStatsDialog;
 
-import javax.swing.AbstractAction;
 import java.awt.event.ActionEvent;
 
-public class TagStatsAction extends AbstractAction {
+/**
+ * An action to launch the TagStatsDialog, for viewing tag index statistics.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class TagStatsAction extends EnhancedAction {
+
+    private static final String NAME = "Tag index statistics...";
 
     public TagStatsAction() {
-        super("Tag index statistics...");
+        super(NAME);
     }
 
     @Override

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/threads/BatchTagThread.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/threads/BatchTagThread.java
@@ -1,5 +1,6 @@
 package ca.corbett.imageviewer.extensions.ice.threads;
 
+import ca.corbett.extras.image.ImageUtil;
 import ca.corbett.extras.io.FileSystemUtil;
 import ca.corbett.extras.progress.SimpleProgressWorker;
 import ca.corbett.imageviewer.extensions.ice.TagIndex;
@@ -125,7 +126,10 @@ public class BatchTagThread extends SimpleProgressWorker {
         // supplied with one, or by interrogating our imageSet, if we were given one.
         List<File> imageFiles;
         if (startDir != null) {
-            imageFiles = FileSystemUtil.findFiles(startDir, isRecursive, ThumbContainerPanel.getImageExtensions());
+            imageFiles = FileSystemUtil.findFiles(startDir, isRecursive)
+                                       .stream()
+                                       .filter(ImageUtil::isImageFile)
+                                       .toList();
         }
         else if (imageSet != null) {
             List<String> imagePaths = imageSet.getImageFilePaths();

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
@@ -6,6 +6,7 @@ import ca.corbett.extras.properties.ComboProperty;
 import ca.corbett.extras.properties.IntegerProperty;
 import ca.corbett.extras.properties.ShortTextProperty;
 import ca.corbett.imageviewer.AppConfig;
+import ca.corbett.imageviewer.ImageViewerResources;
 import ca.corbett.imageviewer.Version;
 import ca.corbett.imageviewer.extensions.ImageViewerExtensionManager;
 import ca.corbett.imageviewer.extensions.ice.IceExtension;
@@ -71,16 +72,12 @@ public class QuickTagPanel extends JPanel {
             sourceRootDir.mkdirs();
         }
         if (iconAddTag == null) { // only load these once
-            try {
-                iconAddTag = ImageSetPanel.loadIconImage("icon-plus.png");
-                iconEditTagGroup = ImageSetPanel.loadIconImage("icon-document-edit.png");
-                iconRemoveTagGroup = ImageSetPanel.loadIconImage("icon-x.png");
-                iconExpand = ImageSetPanel.loadIconImage("icon-zoom-in2.png");
-                iconContract = ImageSetPanel.loadIconImage("icon-zoom-out2.png");
-            }
-            catch (IOException ioe) {
-                log.log(Level.SEVERE, "QuickTagPanel: error loading icon images: " + ioe.getMessage(), ioe);
-            }
+            final int iconSize = 18; // not configurable
+            iconAddTag = ImageViewerResources.getIconPlus(iconSize);
+            iconEditTagGroup = ImageViewerResources.getIconImageSetEdit(iconSize);
+            iconRemoveTagGroup = ImageViewerResources.getIconDelete(iconSize);
+            iconExpand = ImageViewerResources.getIconZoomIn(iconSize);
+            iconContract = ImageViewerResources.getIconZoomOut(iconSize);
         }
         reset();
     }

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/TagPreviewPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/TagPreviewPanel.java
@@ -9,7 +9,6 @@ import ca.corbett.imageviewer.extensions.ice.actions.TagSingleImageAction;
 import ca.corbett.imageviewer.ui.ImageInstance;
 import ca.corbett.imageviewer.ui.MainWindow;
 
-import javax.swing.BorderFactory;
 import javax.swing.JPanel;
 import java.awt.BorderLayout;
 import java.awt.Color;
@@ -39,7 +38,7 @@ public class TagPreviewPanel extends JPanel {
             public void mouseClicked(MouseEvent e) {
                 ImageInstance currentImage = MainWindow.getInstance().getSelectedImage();
                 if (! currentImage.isEmpty()) {
-                    new TagSingleImageAction().actionPerformed(null);
+                    TagSingleImageAction.getInstance().actionPerformed(null);
                 }
             }
         });

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/TagPreviewPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/TagPreviewPanel.java
@@ -8,6 +8,8 @@ import ca.corbett.imageviewer.extensions.ice.TagList;
 import ca.corbett.imageviewer.extensions.ice.actions.TagSingleImageAction;
 import ca.corbett.imageviewer.ui.ImageInstance;
 import ca.corbett.imageviewer.ui.MainWindow;
+import ca.corbett.imageviewer.ui.UIReloadable;
+import ca.corbett.imageviewer.ui.actions.ReloadUIAction;
 
 import javax.swing.JPanel;
 import java.awt.BorderLayout;
@@ -20,7 +22,7 @@ import java.awt.event.MouseEvent;
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  */
-public class TagPreviewPanel extends JPanel {
+public class TagPreviewPanel extends JPanel implements UIReloadable {
     private final LongTextField textField;
 
     public TagPreviewPanel() {
@@ -32,7 +34,7 @@ public class TagPreviewPanel extends JPanel {
         textField.setEnabled(false);
         this.setBackground(Color.GREEN);
         textField.getTextArea().setColumns(10); // dumb! remove once swing-extras #119 fix is available in 2.5 release
-        textField.setHelpText("Read-only display. Press Ctrl+G to edit tags.");
+        textField.setHelpText(getHelpText());
         textField.getTextArea().addMouseListener(new MouseAdapter() {
             @Override
             public void mouseClicked(MouseEvent e) {
@@ -44,6 +46,41 @@ public class TagPreviewPanel extends JPanel {
         });
         formPanel.add(textField);
         add(formPanel, BorderLayout.CENTER);
+        ReloadUIAction.getInstance().registerReloadable(this);
+    }
+
+    /**
+     * Returns helpful text showing the currently-configured keyboard shortcut for the tag dialog.
+     */
+    private String getHelpText() {
+        return "Read-only display. Use the tag dialog to edit tags.";
+
+        // It sure would be nice to show the actual keystroke here!
+        // But something strange is happening and it's way too late at night to debug it.
+        // The code is getting executed in a wonky order, such that the code below
+        // is somehow always one out of date. That is, on startup, it's fine, but
+        // remap the shortcut and it still shows the old value. Then, remap it again,
+        // and it shows the new value from the first remap, but not the current one, and so on.
+        // NO IDEA why, so leaving it for now.
+        /*
+        KeyStroke keystroke = TagSingleImageAction.getInstance().getAcceleratorKey();
+        System.out.println("The action has a keystroke of: " + keystroke);
+        if (keystroke != null) {
+            return "Read-only display. Press " + KeyStrokeManager.keyStrokeToString(keystroke) + " to edit tags.";
+        }
+        else {
+            // Our TagPreviewPanel loads before our accelerator gets set, so peek() the value of it,
+            // to determine if this null is an actual null or a false alarm null.
+            String keystrokeStr = AppConfig.peek(Version.APP_CONFIG_FILE, "Keystrokes.ICE.quickTagPanel.keyStroke");
+            System.out.println("Peeked keystroke: " + keystrokeStr);
+            if (keystrokeStr != null && KeyStrokeManager.parseKeyStroke(keystrokeStr) != null) {
+                return "Read-only display. Press " + keystrokeStr + " to edit tags.";
+            }
+
+            // Oh, I guess it actually is null:
+            return "Read-only display. Use the tag dialog to edit tags."; // But you have to bring it up yourself!
+        }
+        */
     }
 
     public void clearTags() {
@@ -52,5 +89,11 @@ public class TagPreviewPanel extends JPanel {
 
     public void setTagList(TagList tagList) {
         textField.setText(tagList.toString());
+    }
+
+    @Override
+    public void reloadUI() {
+        // Our keyboard shortcut may have changed, so update the help text:
+        textField.setHelpText(getHelpText());
     }
 }

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/RandomImageSetDialog.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/RandomImageSetDialog.java
@@ -1,6 +1,7 @@
 package ca.corbett.imageviewer.extensions.ice.ui.dialogs;
 
 import ca.corbett.extras.MessageUtil;
+import ca.corbett.extras.image.ImageUtil;
 import ca.corbett.extras.io.FileSystemUtil;
 import ca.corbett.extras.progress.MultiProgressDialog;
 import ca.corbett.extras.progress.SimpleProgressWorker;
@@ -334,7 +335,10 @@ public class RandomImageSetDialog extends JDialog {
             int taggedCount = 0;
             int untaggedCount = 0;
 
-            List<File> allFiles = FileSystemUtil.findFiles(dir, recursive, ThumbContainerPanel.getImageExtensions());
+            List<File> allFiles = FileSystemUtil.findFiles(dir, recursive)
+                                                .stream()
+                                                .filter(ImageUtil::isImageFile)
+                                                .toList();
             fireProgressBegins(allFiles.size());
 
             try {

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/TagDirStatsDialog.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/TagDirStatsDialog.java
@@ -1,5 +1,6 @@
 package ca.corbett.imageviewer.extensions.ice.ui.dialogs;
 
+import ca.corbett.extras.image.ImageUtil;
 import ca.corbett.extras.io.FileSystemUtil;
 import ca.corbett.extras.progress.MultiProgressDialog;
 import ca.corbett.extras.progress.SimpleProgressWorker;
@@ -154,7 +155,10 @@ public class TagDirStatsDialog extends JDialog {
 
             int totalTagsFound = 0;
 
-            List<File> allFiles = FileSystemUtil.findFiles(dir, recursive, ThumbContainerPanel.getImageExtensions());
+            List<File> allFiles = FileSystemUtil.findFiles(dir, recursive)
+                                                .stream()
+                                                .filter(ImageUtil::isImageFile)
+                                                .toList();
             fireProgressBegins(allFiles.size());
 
             try {

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/extInfo.json
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/extInfo.json
@@ -1,9 +1,9 @@
 {
   "name": "ICE",
   "author": "steve@corbett.ca",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "targetAppName": "ImageViewer",
-  "targetAppVersion": "2.4",
+  "targetAppVersion": "3.0",
   "shortDescription": "Semantic tagging and searching of images.",
   "longDescription": "Originally the Image Classification Engine, ICE allows you to add semantic tags to images and then search for them by tag."
 }


### PR DESCRIPTION
This PR addresses issue #40 by preparing a 3.0.0-SNAPSHOT release of this extension that is updated for the new 3.0-SNAPSHOT release of the parent application. As this is a major release of the parent application, not a minor/patch release, there are several extension-breaking changes to address.

Specific changes:
- update versions where necessary
- (using SNAPSHOT for now, will remove that before final release)
- Parent application changed handling of menus and menu items
- Parent application now insists on the use of the `EnhancedAction` class from swing-extras (previously was using the Java `AbstractAction` as a base for action classes).
- Parent application now supports configurable keyboard shortcut properties! 
- Found and fixed a bug in ScanDirAction where UI work was being done outside the Swing EDT (unrelated to this upgrade, but necessary to fix)
