### PR TITLE
Issue #39 - persist quick tag panel settings independently for left/right positions

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
@@ -79,7 +79,8 @@ public class IceExtension extends ImageViewerExtension {
     public static final String quickTagPanelPositionProp = "ICE.General.quickTagPanelPosition";
     public static final String quickTagPanelWidthProp = "ICE.General.quickTagPanelWidth";
     public static final String fontSizeProp = "Thumbnails.Companion files.linkFontSize";
-    public static final String quickTagSourceProp = "Hidden.quickTags.source";
+    public static final String quickTagLeftSourceProp = "Hidden.quickTagsLeft.source";
+    public static final String quickTagRightSourceProp = "Hidden.quickTagsRight.source";
     public static final String quickTagShortcutProp = AppConfig.KEYSTROKE_PREFIX + "ICE.quickTagPanel";
 
     private final List<TagPreviewPanel> tagPreviewPanels = new ArrayList<>();
@@ -115,7 +116,10 @@ public class IceExtension extends ImageViewerExtension {
         list.add(new IntegerProperty(quickTagPanelWidthProp, "Quick tag panel width:", 200, 120, 300, 10));
         list.add(new IntegerProperty(fontSizeProp, "Hyperlink font size", 10, 8, 16, 1));
         list.add(new BooleanProperty(TagIndex.PROP_NAME, "Enable tag index for faster searches", true));
-        list.add(new ShortTextProperty(quickTagSourceProp, "quickTagsSource", QuickTagPanel.DEFAULT_SOURCE_NAME).setExposed(false));
+        list.add(new ShortTextProperty(quickTagLeftSourceProp, "quickTagsLeftSource",
+                                       QuickTagPanel.DEFAULT_SOURCE_NAME).setExposed(false));
+        list.add(new ShortTextProperty(quickTagRightSourceProp, "quickTagsRightSource",
+                                       QuickTagPanel.DEFAULT_SOURCE_NAME).setExposed(false));
         list.add(new KeyStrokeProperty(quickTagShortcutProp, "Image tag dialog:",
                                        KeyStrokeManager.parseKeyStroke("Ctrl+G"),
                                        TagSingleImageAction.getInstance())
@@ -187,7 +191,7 @@ public class IceExtension extends ImageViewerExtension {
         }
 
         if (getQuickTagPositionFromConfig().contains(position)) {
-            QuickTagPanel panel = new QuickTagPanel(); // create a new one on each request
+            QuickTagPanel panel = new QuickTagPanel(position); // create a new one on each request
             quickTagPanels.add(panel);
             JScrollPane scrollPane = new JScrollPane(panel);
             scrollPane.getVerticalScrollBar().setUnitIncrement(10);

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
@@ -44,7 +44,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * The QuickTagPanel presents a configurable list of commonly-used tags that can applied to the
+ * The QuickTagPanel presents a configurable list of commonly-used tags that can be applied to the
  * currently selected image with a single button click. The user can opt to place this panel
  * either to the left of the main image, or to the right of it, or have one QuickTagPanel in
  * each of those positions. The panel(s) can also be hidden entirely in application settings.

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
@@ -2,12 +2,14 @@ package ca.corbett.imageviewer.extensions.ice.ui;
 
 import ca.corbett.extras.LookAndFeelManager;
 import ca.corbett.extras.io.FileSystemUtil;
+import ca.corbett.extras.properties.AbstractProperty;
 import ca.corbett.extras.properties.ComboProperty;
 import ca.corbett.extras.properties.IntegerProperty;
 import ca.corbett.extras.properties.ShortTextProperty;
 import ca.corbett.imageviewer.AppConfig;
 import ca.corbett.imageviewer.ImageViewerResources;
 import ca.corbett.imageviewer.Version;
+import ca.corbett.imageviewer.extensions.ImageViewerExtension;
 import ca.corbett.imageviewer.extensions.ImageViewerExtensionManager;
 import ca.corbett.imageviewer.extensions.ice.IceExtension;
 import ca.corbett.imageviewer.extensions.ice.TagIndex;
@@ -17,7 +19,6 @@ import ca.corbett.imageviewer.extensions.ice.ui.dialogs.QuickTagSourceDialog;
 import ca.corbett.imageviewer.ui.ImageInstance;
 import ca.corbett.imageviewer.ui.MainWindow;
 import ca.corbett.imageviewer.ui.actions.ReloadUIAction;
-import ca.corbett.imageviewer.ui.imagesets.ImageSetPanel;
 import org.apache.commons.io.FilenameUtils;
 
 import javax.swing.ImageIcon;
@@ -26,7 +27,6 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.SwingConstants;
-import javax.swing.SwingUtilities;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -37,13 +37,47 @@ import java.awt.Insets;
 import java.awt.event.ActionListener;
 import java.awt.image.BufferedImage;
 import java.io.File;
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * The QuickTagPanel presents a configurable list of commonly-used tags that can applied to the
+ * currently selected image with a single button click. The user can opt to place this panel
+ * either to the left of the main image, or to the right of it, or have one QuickTagPanel in
+ * each of those positions. The panel(s) can also be hidden entirely in application settings.
+ * <p>
+ * <b>Tag groups:</b> Tags can be grouped together into named groups, which are presented
+ * in separate collapsible sections in the panel. Each group offers options for ordering the
+ * tags within it, as well as renaming or deleting the group itself.
+ * </p>
+ * <p>
+ * <b>Persistence:</b> Quick tag groups are persisted as JSON files in the
+ * "quickTags" directory located in the application settings directory. Each source has its own
+ * subdirectory within that directory, allowing users to maintain separate sets of quick tags
+ * for different contexts (different types of images or projects, for example). Each panel's
+ * visibility state, position, and contents are automatically restored when the application is restarted.
+ * Hiding the quick tags panel in application settings does not remove any configured tag groups!
+ * You can re-enable the panel at any time to regain access to your quick tags.
+ * </p>
+ * <p>
+ * <b>What if the current image already has the selected tag?</b> The tag buttons on this panel
+ * act as a toggle. If the selected tag is not present in the image's tag list, it is added.
+ * If the tag is already present, it is removed. You can immediately see the results of the operation
+ * in the tag preview pane, which by default is located at the bottom of the main image view.
+ * Alternatively, you can press Ctrl+G (or whatever you have mapped that shortcut to) in order
+ * to bring up the tag dialog and view/edit the tag list for the current image.
+ * </p>
+ * <p>
+ * Minor TODO here: now that the application supports custom color schemes (as of 3.0), we should
+ * either use the options set by the application, or add our own customization options for the
+ * user to modify our colors. Currently, we always use colors from the current Look and Feel.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
 public class QuickTagPanel extends JPanel {
 
     private static final Logger log = Logger.getLogger(QuickTagPanel.class.getName());
@@ -53,6 +87,7 @@ public class QuickTagPanel extends JPanel {
     public static final int SideMargin = 16;
     public static final int RowHeight = 25;
 
+    private final ImageViewerExtension.ExtraPanelPosition position;
     private final File sourceRootDir;
     private File sourceDir;
     private int panelWidth;
@@ -65,7 +100,27 @@ public class QuickTagPanel extends JPanel {
     private static String currentSource;
     private final Map<String, Boolean> isExpandedMap = new HashMap<>();
 
-    public QuickTagPanel() {
+    /**
+     * Creates a QuickTagPanel for the specified position.
+     * Only left and right positions are supported! All other positions
+     * will result in an IllegalArgumentException.
+     * <p>
+     * The position is a required parameter because the panel's contents are
+     * persisted according to its position. This allows the "both left and right position"
+     * option to function correctly, with each panel maintaining its own independent
+     * set of quick tag groups.
+     * </p>
+     *
+     * @param position The desired position, either Left or Right.
+     */
+    public QuickTagPanel(ImageViewerExtension.ExtraPanelPosition position) {
+        if (position != ImageViewerExtension.ExtraPanelPosition.Left
+                && position != ImageViewerExtension.ExtraPanelPosition.Right) {
+            log.log(Level.SEVERE, "QuickTagPanel must be created for left or right position, got: " + position);
+            throw new IllegalArgumentException("QuickTagPanel is only supported in left or right position.");
+        }
+        this.position = position;
+
         setLayout(new GridBagLayout());
         sourceRootDir = new File(Version.SETTINGS_DIR, "quickTags");
         if (!sourceRootDir.exists()) {
@@ -82,10 +137,16 @@ public class QuickTagPanel extends JPanel {
         reset();
     }
 
+    /**
+     * Returns the name of the currently selected quick tag source for this panel.
+     */
     public String getSource() {
         return currentSource;
     }
 
+    /**
+     * Reloads the panel contents from the currently selected quick tag source.
+     */
     public void reset() {
         currentSource = getSourceFromProperties();
         sourceDir = DEFAULT_SOURCE_NAME.equals(currentSource)
@@ -120,19 +181,19 @@ public class QuickTagPanel extends JPanel {
         addHidePanelButton(rowNumber++);
         addBottomSpacer(rowNumber);
 
-        // Swing wonkiness... adding or removing stuff from a container sometimes needs a kick
-        // in the pants before the change actually shows up.
-        final JPanel thisPanel = this;
-        SwingUtilities.invokeLater(new Runnable() {
-            @Override
-            public void run() {
-                thisPanel.invalidate();
-                thisPanel.revalidate();
-                thisPanel.repaint();
-            }
-        });
+        // Force a repaint to display the changes:
+        this.invalidate();
+        this.revalidate();
+        this.repaint();
     }
 
+    /**
+     * Applies the specified tag to the current image - this means adding it to the image's
+     * tag list if it is not already present, or removing it if it is. Remember that tags are
+     * case-insensitive, so "tag", "Tag", and "TAG" are all considered the same tag.
+     *
+     * @param tag The tag in question.
+     */
     private void executeTagAction(String tag) {
         ImageInstance image = MainWindow.getInstance().getSelectedImage();
         if (! image.isEmpty()) {
@@ -185,18 +246,6 @@ public class QuickTagPanel extends JPanel {
             headerLabel.setExpanded(false);
         }
         add(headerLabel, gbc);
-    }
-
-    private void addSpacer(int row) {
-        GridBagConstraints gbc = new GridBagConstraints();
-        gbc.gridwidth = 3;
-        gbc.gridy = row;
-        gbc.anchor = GridBagConstraints.WEST;
-        gbc.fill = GridBagConstraints.BOTH;
-        gbc.insets = new Insets(0,SideMargin,0,SideMargin);
-        JLabel label = new JLabel(" ");
-        label.setOpaque(true);
-        add(label, gbc);
     }
 
     private void addButton(JButton button, int row) {
@@ -315,17 +364,29 @@ public class QuickTagPanel extends JPanel {
         }
     }
 
+    /**
+     * Hides all QuickTagPanels and silently updates application preferences to keep them hidden.
+     * Nothing is deleted or lost as a result of this operation! The panels can be re-enabled
+     * at any time in application settings.
+     */
     private void hidePanel() {
-        //noinspection unchecked
-        ComboProperty<String> prop = (ComboProperty<String>)AppConfig
+        // Get the property that controls quick tag panel position:
+        AbstractProperty prop = AppConfig
                 .getInstance()
                 .getPropertiesManager()
                 .getProperty(IceExtension.quickTagPanelPositionProp);
-        if (prop != null) {
-            prop.setSelectedIndex(0);
-            ReloadUIAction.getInstance().actionPerformed(null); // overkill? we just want to hide the panel...
+
+        if (prop instanceof ComboProperty<?> comboProp) {
+            comboProp.setSelectedIndex(0); // "None" position
+            AppConfig.getInstance().save(); // force silent save to persist this immediately
+
+            // It may seem like overkill to reload the entire UI just to hide these panels,
+            // but the main image view needs to be laid out again as a result of this change.
+            ReloadUIAction.getInstance().actionPerformed(null);
+
+            // Explain to the user what just happened and how to reverse it later:
             MainWindow.getInstance().showMessageDialog("Quick tags hidden",
-                                                       "You can re-enable the quick tags panel in application settings.");
+                                                       "You can re-enable the quick tag panel(s) in application settings.");
         }
     }
 
@@ -366,9 +427,15 @@ public class QuickTagPanel extends JPanel {
         }
     }
 
+    /**
+     * Represents a header label with a collapse/expand button.
+     * When collapsed, only the header label and the expand button are shown.
+     * This is great for having a potentially large number of tag groups without requiring
+     * a lot of vertical scrolling to see them all.
+     */
     private static class HeaderLabel extends JPanel {
         private final String labelText;
-        private JButton btnExpander;
+        private final JButton btnExpander;
         private boolean isExpanded;
 
         public HeaderLabel(String labelText, int panelWidth) {
@@ -417,22 +484,40 @@ public class QuickTagPanel extends JPanel {
         }
     }
 
+    /**
+     * If our source is changed, we need to update the appropriate property
+     * in application settings and persist it so that it is restored on next launch.
+     *
+     * @param source The name of the new source.
+     */
     private void setSourceInProperties(String source) {
-        ShortTextProperty prop = (ShortTextProperty)AppConfig.getInstance().getPropertiesManager().getProperty(IceExtension.quickTagSourceProp);
-        if (prop == null) {
+        String propName = position == ImageViewerExtension.ExtraPanelPosition.Left
+                ? IceExtension.quickTagLeftSourceProp
+                : IceExtension.quickTagRightSourceProp;
+        AbstractProperty prop = AppConfig.getInstance().getPropertiesManager().getProperty(propName);
+        if (!(prop instanceof ShortTextProperty shortTextProp)) {
             log.warning("QuickTagPanel: Unable to find source property, unable to save source preference.");
             return;
         }
-        prop.setValue(source);
-        AppConfig.getInstance().save();
+        shortTextProp.setValue(source);
+        AppConfig.getInstance().save(); // force silent save to persist this immediately
     }
 
+    /**
+     * Returns the persisted name of our tag source from application settings.
+     * If there is no persisted source for our position, the default source name is returned.
+     *
+     * @return A tag source name for this panel.
+     */
     private String getSourceFromProperties() {
-        ShortTextProperty prop = (ShortTextProperty)AppConfig.getInstance().getPropertiesManager().getProperty(IceExtension.quickTagSourceProp);
-        if (prop == null) {
+        String propName = position == ImageViewerExtension.ExtraPanelPosition.Left
+                ? IceExtension.quickTagLeftSourceProp
+                : IceExtension.quickTagRightSourceProp;
+        AbstractProperty prop = AppConfig.getInstance().getPropertiesManager().getProperty(propName);
+        if (!(prop instanceof ShortTextProperty shortTextProp)) {
             log.warning("QuickTagPanel: Unable to find source property, reverting to default source.");
             return DEFAULT_SOURCE_NAME;
         }
-        return prop.getValue();
+        return shortTextProp.getValue();
     }
 }

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
@@ -91,13 +91,13 @@ public class QuickTagPanel extends JPanel {
     private final File sourceRootDir;
     private File sourceDir;
     private int panelWidth;
-    private static BufferedImage iconAddTag;
-    private static BufferedImage iconEditTagGroup;
-    private static BufferedImage iconRemoveTagGroup;
-    private static BufferedImage iconExpand;
-    private static BufferedImage iconContract;
+    private final BufferedImage iconAddTag;
+    private final BufferedImage iconEditTagGroup;
+    private final BufferedImage iconRemoveTagGroup;
+    private final BufferedImage iconExpand;
+    private final BufferedImage iconContract;
 
-    private static String currentSource;
+    private String currentSource;
     private final Map<String, Boolean> isExpandedMap = new HashMap<>();
 
     /**
@@ -126,15 +126,14 @@ public class QuickTagPanel extends JPanel {
         if (!sourceRootDir.exists()) {
             sourceRootDir.mkdirs();
         }
-        if (iconAddTag == null) { // only load these once
-            final int iconSize = 18; // not configurable
-            iconAddTag = ImageViewerResources.getIconPlus(iconSize);
-            iconEditTagGroup = ImageViewerResources.getIconImageSetEdit(iconSize);
-            iconRemoveTagGroup = ImageViewerResources.getIconDelete(iconSize);
-            iconExpand = ImageViewerResources.getIconZoomIn(iconSize);
-            iconContract = ImageViewerResources.getIconZoomOut(iconSize);
-        }
-        reset();
+        final int iconSize = 18; // not configurable
+        iconAddTag = ImageViewerResources.getIconPlus(iconSize);
+        iconEditTagGroup = ImageViewerResources.getIconImageSetEdit(iconSize);
+        iconRemoveTagGroup = ImageViewerResources.getIconDelete(iconSize);
+        iconExpand = ImageViewerResources.getIconZoomIn(iconSize);
+        iconContract = ImageViewerResources.getIconZoomOut(iconSize);
+
+        reset(); // Force a load of our contents
     }
 
     /**
@@ -433,7 +432,7 @@ public class QuickTagPanel extends JPanel {
      * This is great for having a potentially large number of tag groups without requiring
      * a lot of vertical scrolling to see them all.
      */
-    private static class HeaderLabel extends JPanel {
+    private class HeaderLabel extends JPanel {
         private final String labelText;
         private final JButton btnExpander;
         private boolean isExpanded;

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
@@ -4,6 +4,7 @@ Author: Steve Corbett
 Version 3.0.0 [TODO - release date]
   #43 - Ensure TagPreviewPanel shows correct shortcut
   #40 - Upgrade to ImageViewer 3.0 (major update!)
+  #39 - Persist left/right quick tag panels separately
 
 Version 2.4.0 [2026-01-26]
   #34 - Add "Tag directory stats" dialog in filesystem mode


### PR DESCRIPTION
This PR addresses issue #39 by allowing the quick tag panel to persist its settings separately for left and right positions, instead of having one persistence option for both positions. This allows the user to have different contents showing simultaneously in left and right positions, and have them both persist and be restored correctly on next application launch.

Also improved javadocs throughout the QuickTagPanel class, as they were lacking.