### PR TITLE
Issue 32 tag hotkeys

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
@@ -24,6 +24,8 @@ import ca.corbett.imageviewer.extensions.ice.actions.TagSingleImageAction;
 import ca.corbett.imageviewer.extensions.ice.actions.TagStatsAction;
 import ca.corbett.imageviewer.extensions.ice.ui.QuickTagPanel;
 import ca.corbett.imageviewer.extensions.ice.ui.TagPreviewPanel;
+import ca.corbett.imageviewer.extensions.ice.ui.formfield.ReservedKeyStrokeWorkaround2;
+import ca.corbett.imageviewer.extensions.ice.ui.formfield.TagHotkeyProperty;
 import ca.corbett.imageviewer.ui.ImageInstance;
 import ca.corbett.imageviewer.ui.MainWindow;
 import ca.corbett.imageviewer.ui.ThumbPanel;
@@ -82,6 +84,7 @@ public class IceExtension extends ImageViewerExtension {
     public static final String quickTagLeftSourceProp = "Hidden.quickTagsLeft.source";
     public static final String quickTagRightSourceProp = "Hidden.quickTagsRight.source";
     public static final String quickTagShortcutProp = AppConfig.KEYSTROKE_PREFIX + "ICE.quickTagPanel";
+    public static final String tagHotkeyPropPrefix = AppConfig.KEYSTROKE_PREFIX + "ICE.tagHotKey";
 
     private final List<TagPreviewPanel> tagPreviewPanels = new ArrayList<>();
     private final List<QuickTagPanel> quickTagPanels = new ArrayList<>();
@@ -124,6 +127,26 @@ public class IceExtension extends ImageViewerExtension {
                                        KeyStrokeManager.parseKeyStroke("Ctrl+G"),
                                        TagSingleImageAction.getInstance())
                          .setAllowBlank(true));
+
+        // Add a few configurable hotkeys for commonly-used tags:
+        for (int i = 1; i <= 8; i++) {
+            // Why 8? I dunno, seems like a reasonable number.
+            // Too many and the properties form will scroll vertically too much.
+            // Too few and there's not enough value in this feature.
+            // We'll use Ctrl+F1 through Ctrl+F8 as the default hotkeys, and there
+            // will be no tags assigned by default. The user can configure
+            // as needed, or blank them all out if they don't want to use this feature.
+            String helpText = "<html>Assign commonly used tags to a hotkey for<br>"
+                    + "quick application to the currently selected image.<br>" +
+                    "You can comma-separate the list to set more than one tag at a time.<br>" +
+                    "The tags are added to the image's tag list, unless they are already there.</html>";
+            list.add(new TagHotkeyProperty(tagHotkeyPropPrefix + i, "Tag hotkey " + i + ":")
+                             .setKeyStroke(KeyStrokeManager.parseKeyStroke("Ctrl+F" + i))
+                             .setAllowBlank(true)
+                             .setHelpText(helpText)
+                             .addFormFieldGenerationListener(new ReservedKeyStrokeWorkaround2()));
+        }
+
         return list;
     }
 

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/TagList.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/TagList.java
@@ -17,6 +17,8 @@ public class TagList {
     private static final Logger log = Logger.getLogger(TagList.class.getName());
     private static final Set<Character> DISALLOWED_TAG_CHARS = Set.of('{', '}', '|', ',');
 
+    public static final String TAG_FORMAT_ERROR = "Tags cannot contain the characters: { } |";
+
     private final Set<String> tags = new LinkedHashSet<>();
     private File persistenceFile;
 
@@ -155,6 +157,29 @@ public class TagList {
             }
         }
         return sb.toString();
+    }
+
+    /**
+     * Reports whether the given tag string is free of disallowed characters.
+     *
+     * @param tagString Any candidate tag string, comma-separated or a single tag.
+     * @return true if the tag string is valid, false if it contains disallowed characters.
+     */
+    public static boolean isValidTagString(String tagString) {
+        if (tagString == null || tagString.isBlank()) {
+            return false;
+        }
+
+        // Check if any tag in the given tagString (which may be comma-separated) contains disallowed characters:
+        String[] tags = tagString.split(",");
+        for (String tag : tags) {
+            for (char c : tag.toCharArray()) {
+                if (DISALLOWED_TAG_CHARS.contains(c)) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     public void save() {

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/TagList.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/TagList.java
@@ -160,12 +160,12 @@ public class TagList {
     }
 
     /**
-     * Reports whether the given tag string is free of disallowed characters.
+     * Reports whether the given tag string is non-empty and free of disallowed characters.
      *
      * @param tagString Any candidate tag string, comma-separated or a single tag.
-     * @return true if the tag string is valid, false if it contains disallowed characters.
+     * @return true if the tag string is non-empty and valid, false if it is null, blank, or contains disallowed characters.
      */
-    public static boolean isValidTagString(String tagString) {
+    public static boolean isValidNonEmptyTagString(String tagString) {
         if (tagString == null || tagString.isBlank()) {
             return false;
         }

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/TagHotkeyAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/TagHotkeyAction.java
@@ -1,0 +1,95 @@
+package ca.corbett.imageviewer.extensions.ice.actions;
+
+import ca.corbett.extras.EnhancedAction;
+import ca.corbett.imageviewer.extensions.ImageViewerExtensionManager;
+import ca.corbett.imageviewer.extensions.ice.TagIndex;
+import ca.corbett.imageviewer.extensions.ice.TagList;
+import ca.corbett.imageviewer.ui.ImageInstance;
+import ca.corbett.imageviewer.ui.MainWindow;
+import org.apache.commons.io.FilenameUtils;
+
+import java.awt.event.ActionEvent;
+import java.io.File;
+import java.util.logging.Logger;
+
+/**
+ * An action that can be invoked when a hotkey is pressed to
+ * add a predefined list of tags to the currently selected image.
+ * <p>
+ * Unlike the quick tags panel, this is not a toggle! The tag(s)
+ * are added to the image's existing tag list only if they are
+ * not already present. Otherwise, there is no change.
+ * </p>
+ * <p>
+ * The coordinating class is TagHotkeyProperty. You generally
+ * shouldn't need to instantiate this class directly. Just create
+ * a TagHotkeyProperty and treat it more or less as you would
+ * treat any other KeyStrokeProperty.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since 3.0.0
+ */
+public class TagHotkeyAction extends EnhancedAction {
+
+    private static final Logger log = Logger.getLogger(TagHotkeyAction.class.getName());
+    private final TagList tagList;
+
+    /**
+     * Creates a TagHotkeyAction with the given name.
+     */
+    public TagHotkeyAction(String name) {
+        super(name);
+        tagList = new TagList();
+    }
+
+    /**
+     * Sets the tag list to be associated with this hotkey action.
+     * Null or empty input is fine - that will blank out the tag list.
+     * If this action is invoked with an empty tag list, it will do nothing.
+     */
+    public TagHotkeyAction setTagList(TagList tagList) {
+        this.tagList.clear();
+        this.tagList.addAll(tagList == null ? new TagList() : tagList);
+        return this;
+    }
+
+    /**
+     * Returns the tag list associated with this hotkey action.
+     * May be empty.
+     */
+    public TagList getTagList() {
+        return tagList;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        // If we have no tag list, do nothing:
+        if (tagList.isEmpty()) {
+            log.warning(getName()
+                                + " no TagList is set for this hotkey. You can configure this in application settings.");
+            return;
+        }
+
+        // Make sure we have a selected image:
+        ImageInstance currentImage = MainWindow.getInstance().getSelectedImage();
+        if (currentImage.isEmpty()) {
+            MainWindow.getInstance().showMessageDialog(NAME, "Nothing selected.");
+            return;
+        }
+
+        // Figure out where this tag file should live:
+        // Note: it's not an error if this file does not yet exist...
+        File file = new File(currentImage.getImageFile().getParentFile(),
+                             FilenameUtils.getBaseName(currentImage.getImageFile().getName()) + ".ice");
+        TagList savedList = TagList.fromFile(file); // Will be empty if file does not exist
+
+        // Add our tags to the saved list and save it:
+        savedList.addAll(tagList); // idempotent! Does nothing if they're already there, which is fine.
+        savedList.save();
+
+        // Update the tag index and then re-select the current image to refresh it:
+        TagIndex.getInstance().addOrUpdateEntry(currentImage.getImageFile(), savedList.getPersistenceFile());
+        ImageViewerExtensionManager.getInstance().imageSelected(currentImage);
+    }
+}

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/TagHotkeyAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/TagHotkeyAction.java
@@ -34,6 +34,7 @@ public class TagHotkeyAction extends EnhancedAction {
 
     private static final Logger log = Logger.getLogger(TagHotkeyAction.class.getName());
     private final TagList tagList;
+    private boolean warningIssued = false;
 
     /**
      * Creates a TagHotkeyAction with the given name.
@@ -51,6 +52,7 @@ public class TagHotkeyAction extends EnhancedAction {
     public TagHotkeyAction setTagList(TagList tagList) {
         this.tagList.clear();
         this.tagList.addAll(tagList == null ? new TagList() : tagList);
+        warningIssued = false;
         return this;
     }
 
@@ -63,11 +65,20 @@ public class TagHotkeyAction extends EnhancedAction {
     }
 
     @Override
+    public void setAcceleratorKey(String acceleratorKey) {
+        super.setAcceleratorKey(acceleratorKey);
+        warningIssued = false;
+    }
+
+    @Override
     public void actionPerformed(ActionEvent e) {
         // If we have no tag list, do nothing:
         if (tagList.isEmpty()) {
-            log.warning(getName()
-                                + " no TagList is set for this hotkey. You can configure this in application settings.");
+            if (!warningIssued) {
+                log.warning(getName()
+                                    + " no TagList is set for this hotkey. You can configure this in application settings.");
+                warningIssued = true;
+            }
             return;
         }
 

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/TagHotkeyAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/TagHotkeyAction.java
@@ -74,7 +74,7 @@ public class TagHotkeyAction extends EnhancedAction {
         // Make sure we have a selected image:
         ImageInstance currentImage = MainWindow.getInstance().getSelectedImage();
         if (currentImage.isEmpty()) {
-            MainWindow.getInstance().showMessageDialog(NAME, "Nothing selected.");
+            MainWindow.getInstance().showMessageDialog(getName(), "Nothing selected.");
             return;
         }
 

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/formfield/ReservedKeyStrokeWorkaround2.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/formfield/ReservedKeyStrokeWorkaround2.java
@@ -1,0 +1,39 @@
+package ca.corbett.imageviewer.extensions.ice.ui.formfield;
+
+import ca.corbett.extras.properties.AbstractProperty;
+import ca.corbett.extras.properties.FormFieldGenerationListener;
+import ca.corbett.forms.fields.FormField;
+import ca.corbett.imageviewer.AppConfig;
+
+/**
+ * This class works around a bug in KeyStrokeProperty where all attempts to set
+ * a list of reserved keystrokes are ignored. The workaround is to attach a
+ * FormFieldGenerationListener to the property, and set the reserved keystrokes
+ * list directly on the generated KeyStrokeField.
+ * <p>
+ * This bug was discovered in swing-extras 2.7, and is being tracked in
+ * <a href="https://github.com/scorbo2/swing-extras/issues/322">issue 322</a>.
+ * A future release of this extension can remove this workaround once the bug
+ * is fixed in swing-extras.
+ * </p>
+ * <p>
+ * Note: we can't use the ReservedKeyStrokeWorkaround class in the
+ * application core code because it only works with KeyStrokeField instances,
+ * whereas we are working with our own TagHotkeyField class here. This class
+ * is otherwise identical to that one.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since 3.0.0
+ */
+public class ReservedKeyStrokeWorkaround2 implements FormFieldGenerationListener {
+    @Override
+    public void formFieldGenerated(AbstractProperty property, FormField formField) {
+        if (!(formField instanceof TagHotkeyField hotkeyField)) {
+            return;
+        }
+
+        hotkeyField.setReservedKeyStrokes(AppConfig.RESERVED_KEYSTROKES);
+    }
+}
+

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/formfield/ReservedKeyStrokeWorkaround2.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/formfield/ReservedKeyStrokeWorkaround2.java
@@ -33,7 +33,8 @@ public class ReservedKeyStrokeWorkaround2 implements FormFieldGenerationListener
             return;
         }
 
-        hotkeyField.setReservedKeyStrokes(AppConfig.RESERVED_KEYSTROKES);
+        String reservedMsg = hotkeyField.getReservedKeyStrokeMsg();
+        hotkeyField.setReservedKeyStrokes(AppConfig.RESERVED_KEYSTROKES, reservedMsg);
     }
 }
 

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/formfield/TagHotkeyField.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/formfield/TagHotkeyField.java
@@ -42,7 +42,7 @@ import java.util.List;
  *         parseable shortcut string, as defined by KeyStrokeManager.</li>
  *      <li>The tagField is optional. It can be blanked out.</li>
  *      <li>If tagField has a value, it must be a valid tag string
- *         as defined by TagList.isValidTagString().</li>
+ *         as defined by TagList.isValidNonEmptyTagString().</li>
  * </ul>
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
@@ -191,7 +191,7 @@ public class TagHotkeyField extends FormField {
      *         parseable shortcut string, as defined by KeyStrokeManager.</li>
      *      <li>The tagField is optional. It can be blanked out.</li>
      *      <li>If tagField has a value, it must be a valid tag string
-     *         as defined by TagList.isValidTagString().</li>
+     *         as defined by TagList.isValidNonEmptyTagString().</li>
      * </ul>
      */
     private class HotkeyValidator implements FieldValidator<TagHotkeyField> {
@@ -206,7 +206,7 @@ public class TagHotkeyField extends FormField {
 
             // Check tagField first:
             if (!tagText.isBlank()) {
-                if (!TagList.isValidTagString(tagText)) {
+                if (!TagList.isValidNonEmptyTagString(tagText)) {
                     return ValidationResult.invalid(TagList.TAG_FORMAT_ERROR);
                 }
 

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/formfield/TagHotkeyField.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/formfield/TagHotkeyField.java
@@ -1,12 +1,21 @@
 package ca.corbett.imageviewer.extensions.ice.ui.formfield;
 
+import ca.corbett.extras.io.KeyStrokeManager;
 import ca.corbett.forms.fields.FormField;
+import ca.corbett.forms.fields.KeyStrokeField;
 import ca.corbett.forms.validators.FieldValidator;
 import ca.corbett.forms.validators.ValidationResult;
 import ca.corbett.imageviewer.extensions.ice.TagList;
 
+import javax.swing.JLabel;
+import javax.swing.JPanel;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import java.awt.FlowLayout;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A custom FormField implementation for displaying and editing the
@@ -14,22 +23,161 @@ import javax.swing.KeyStroke;
  * to be associated with that hotkey. The idea is that you can
  * assign commonly-used tags to hotkeys for very quick application
  * to images.
+ * <p>
+ *     Our field contains two text fields side-by-side: one for the hotkey,
+ *     and one for the tag string. The hotkey field uses the same
+ *     format as KeyStrokeManager (e.g. "ctrl+alt+T" or "shift+f1").
+ *     The tag string field uses the same format as TagList
+ *     (comma-separated case-insensitive tags, e.g. "tag1, tag2, tag3").
+ * </p>
+ * <p>
+ *     This field adds its own FieldValidator to ensure that the
+ *     field contents are valid:
+ * </p>
+ * <ul>
+ *     <li>The hotkey field is optional. It can be blanked out.
+ *         However, if the tagField has a value, then the hotkey
+ *         field must also have a value.</li>
+ *      <li>If the hotkey field has a value, it must be a valid,
+ *         parseable shortcut string, as defined by KeyStrokeManager.</li>
+ *      <li>The tagField is optional. It can be blanked out.</li>
+ *      <li>If tagField has a value, it must be a valid tag string
+ *         as defined by TagList.isValidTagString().</li>
+ * </ul>
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
- * @since 2.4.0
+ * @since 3.0.0
  */
 public class TagHotkeyField extends FormField {
 
-    private JTextField hotkeyField;
-    private JTextField tagField;
+    private final JTextField hotkeyField;
+    private final JTextField tagField;
+    private String reservedKeyStrokeMsg = KeyStrokeField.RESERVED_MSG;
+    private final List<KeyStroke> reservedKeyStrokes = new ArrayList<>();
 
-    public TagHotkeyField() {
-        // TODO this change has been pulled from the 2.4 release.
-        //      Revisit this for ImageViewer 2.5.
-        //      All that's left to do is combine the two text fields
-        //      into one wrapper panel and add our custom validator to it.
-        //      Then, add a Property wrapper around it, add it to app config,
-        //      and register the key handler.
+    public TagHotkeyField(String label) {
+        fieldLabel.setText(label);
+
+        hotkeyField = new JTextField(6);
+        tagField = new JTextField(10);
+        InternalDocumentListener changeListener = new InternalDocumentListener();
+        hotkeyField.getDocument().addDocumentListener(changeListener);
+        tagField.getDocument().addDocumentListener(changeListener);
+        JPanel wrapperPanel = new JPanel(new FlowLayout(FlowLayout.LEFT, 0, 0));
+        wrapperPanel.add(hotkeyField);
+        wrapperPanel.add(new JLabel("  ")); // cheesy spacer
+        wrapperPanel.add(tagField);
+        fieldComponent = wrapperPanel;
+        addFieldValidator(new HotkeyValidator());
+    }
+
+    /**
+     * Returns the KeyStroke represented by the hotkey field,
+     * or null if the field is blank or invalid.
+     */
+    public KeyStroke getKeyStroke() {
+        String hotkeyText = hotkeyField.getText();
+        if (hotkeyText.isBlank()) {
+            return null;
+        }
+        return KeyStrokeManager.parseKeyStroke(hotkeyText); // might be null if invalid
+    }
+
+    /**
+     * Sets the KeyStroke represented by the hotkey field.
+     * If null is given, the field will be blanked out.
+     */
+    public TagHotkeyField setKeyStroke(KeyStroke keyStroke) {
+        if (keyStroke == null) {
+            hotkeyField.setText("");
+        }
+        else {
+            hotkeyField.setText(KeyStrokeManager.keyStrokeToString(keyStroke));
+        }
+        return this;
+    }
+
+    /**
+     * Returns the TagList represented by the tag field,
+     * or an empty TagList if the field is blank.
+     */
+    public TagList getTagList() {
+        String tagText = tagField.getText();
+        if (tagText.isBlank()) {
+            return new TagList(); // empty tag list
+        }
+        return TagList.of(tagText);
+    }
+
+    /**
+     * Sets the TagList for this field, or blanks it out if null
+     * or an empty TagList is given.
+     */
+    public TagHotkeyField setTagList(TagList tagList) {
+        if (tagList == null || tagList.isEmpty()) {
+            tagField.setText("");
+        }
+        else {
+            tagField.setText(tagList.toString());
+        }
+        return this;
+    }
+
+    /**
+     * Optionally set a list of reserved KeyStrokes that cannot be assigned
+     * using this field. By default, no KeyStrokes are reserved.
+     * The given list will replace any previously set reserved KeyStrokes.
+     */
+    public TagHotkeyField setReservedKeyStrokes(List<KeyStroke> reservedKeyStrokes) {
+        setReservedKeyStrokes(reservedKeyStrokes, KeyStrokeField.RESERVED_MSG);
+        return this;
+    }
+
+    /**
+     * Optionally set a list of reserved KeyStrokes that cannot be assigned,
+     * and also sets a custom message to be used when validation fails
+     * because a reserved KeyStroke was entered. The given list will replace
+     * any previously set reserved KeyStrokes.
+     */
+    public TagHotkeyField setReservedKeyStrokes(List<KeyStroke> reservedKeyStrokes, String reservedMsg) {
+        this.reservedKeyStrokes.clear();
+
+        if (reservedKeyStrokes == null || reservedKeyStrokes.isEmpty()) {
+            return this; // nothing to add
+        }
+
+        this.reservedKeyStrokeMsg = (reservedMsg == null || reservedMsg.isBlank())
+                ? KeyStrokeField.RESERVED_MSG
+                : reservedMsg;
+
+        this.reservedKeyStrokes.addAll(reservedKeyStrokes);
+        return this;
+    }
+
+    /**
+     * Returns a copy of the list of reserved KeyStrokes that cannot be assigned
+     */
+    public List<KeyStroke> getReservedKeyStrokes() {
+        return new ArrayList<>(reservedKeyStrokes);
+    }
+
+    /**
+     * Returns the validation message that will be given if a reserved
+     * KeyStroke is entered.
+     */
+    public String getReservedKeyStrokeMsg() {
+        return reservedKeyStrokeMsg;
+    }
+
+    /**
+     * Sets the validation message that will be given if a reserved
+     * KeyStroke is entered.
+     */
+    public TagHotkeyField setReservedKeyStrokeMsg(String reservedKeyStrokeMsg) {
+        this.reservedKeyStrokeMsg = (reservedKeyStrokeMsg == null || reservedKeyStrokeMsg.isBlank())
+                ? KeyStrokeField.RESERVED_MSG
+                : reservedKeyStrokeMsg;
+        return this;
     }
 
     /**
@@ -46,7 +194,7 @@ public class TagHotkeyField extends FormField {
      *         as defined by TagList.isValidTagString().</li>
      * </ul>
      */
-    private static class HotkeyValidator implements FieldValidator<TagHotkeyField> {
+    private class HotkeyValidator implements FieldValidator<TagHotkeyField> {
 
         private static final String TAG_REQUIRES_HOTKEY = "If a tag is specified, a hotkey must also be specified.";
         private static final String INVALID_KEYSTROKE = "The specified hotkey is not a valid keystroke string.";
@@ -68,17 +216,47 @@ public class TagHotkeyField extends FormField {
             }
 
             if (!hotkeyText.isBlank()) {
-                // This won't work! ImageViewer 2.4 is still on swing-extras 2.6,
-                // which doesn't have KeyStrokeManager.
-                // So, I'm going to park this branch until ImageViewer 2.5.
-                // TODO revisit this
                 KeyStroke parsed = KeyStrokeManager.parseKeyStroke(hotkeyText);
                 if (parsed == null) {
                     return ValidationResult.invalid(INVALID_KEYSTROKE);
                 }
+
+                // Make sure it's not reserved:
+                for (KeyStroke reserved : reservedKeyStrokes) {
+                    if (parsed.equals(reserved)) {
+                        return ValidationResult.invalid(reservedKeyStrokeMsg);
+                    }
+                }
             }
 
             return ValidationResult.valid();
+        }
+    }
+
+    /**
+     * Listens for changes to either of our text fields, and fires a value
+     * changed event when either changes.
+     * <p>
+     * Note that DocumentListener is a little broken in Java Swing, so you
+     * may receive multiple events for a single change. This is an unfortunate
+     * known issue.
+     * </p>
+     */
+    private class InternalDocumentListener implements DocumentListener {
+
+        @Override
+        public void insertUpdate(DocumentEvent e) {
+            fireValueChangedEvent();
+        }
+
+        @Override
+        public void removeUpdate(DocumentEvent e) {
+            fireValueChangedEvent();
+        }
+
+        @Override
+        public void changedUpdate(DocumentEvent e) {
+            fireValueChangedEvent();
         }
     }
 }

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/formfield/TagHotkeyField.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/formfield/TagHotkeyField.java
@@ -1,0 +1,84 @@
+package ca.corbett.imageviewer.extensions.ice.ui.formfield;
+
+import ca.corbett.forms.fields.FormField;
+import ca.corbett.forms.validators.FieldValidator;
+import ca.corbett.forms.validators.ValidationResult;
+import ca.corbett.imageviewer.extensions.ice.TagList;
+
+import javax.swing.JTextField;
+import javax.swing.KeyStroke;
+
+/**
+ * A custom FormField implementation for displaying and editing the
+ * combination of a hotkey (keyboard shortcut) and a tag string
+ * to be associated with that hotkey. The idea is that you can
+ * assign commonly-used tags to hotkeys for very quick application
+ * to images.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since 2.4.0
+ */
+public class TagHotkeyField extends FormField {
+
+    private JTextField hotkeyField;
+    private JTextField tagField;
+
+    public TagHotkeyField() {
+        // TODO this change has been pulled from the 2.4 release.
+        //      Revisit this for ImageViewer 2.5.
+        //      All that's left to do is combine the two text fields
+        //      into one wrapper panel and add our custom validator to it.
+        //      Then, add a Property wrapper around it, add it to app config,
+        //      and register the key handler.
+    }
+
+    /**
+     * Used internally to validate the field automatically.
+     * Our validation constraints:
+     * <ul>
+     *     <li>The hotkey field is optional. It can be blanked out.
+     *         However, if the tagField has a value, then the hotkey
+     *         field must also have a value.</li>
+     *      <li>If the hotkey field has a value, it must be a valid,
+     *         parseable shortcut string, as defined by KeyStrokeManager.</li>
+     *      <li>The tagField is optional. It can be blanked out.</li>
+     *      <li>If tagField has a value, it must be a valid tag string
+     *         as defined by TagList.isValidTagString().</li>
+     * </ul>
+     */
+    private static class HotkeyValidator implements FieldValidator<TagHotkeyField> {
+
+        private static final String TAG_REQUIRES_HOTKEY = "If a tag is specified, a hotkey must also be specified.";
+        private static final String INVALID_KEYSTROKE = "The specified hotkey is not a valid keystroke string.";
+
+        @Override
+        public ValidationResult validate(TagHotkeyField fieldToValidate) {
+            String tagText = fieldToValidate.tagField.getText();
+            String hotkeyText = fieldToValidate.hotkeyField.getText();
+
+            // Check tagField first:
+            if (!tagText.isBlank()) {
+                if (!TagList.isValidTagString(tagText)) {
+                    return ValidationResult.invalid(TagList.TAG_FORMAT_ERROR);
+                }
+
+                if (hotkeyText.isBlank()) {
+                    return ValidationResult.invalid(TAG_REQUIRES_HOTKEY);
+                }
+            }
+
+            if (!hotkeyText.isBlank()) {
+                // This won't work! ImageViewer 2.4 is still on swing-extras 2.6,
+                // which doesn't have KeyStrokeManager.
+                // So, I'm going to park this branch until ImageViewer 2.5.
+                // TODO revisit this
+                KeyStroke parsed = KeyStrokeManager.parseKeyStroke(hotkeyText);
+                if (parsed == null) {
+                    return ValidationResult.invalid(INVALID_KEYSTROKE);
+                }
+            }
+
+            return ValidationResult.valid();
+        }
+    }
+}

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/formfield/TagHotkeyProperty.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/formfield/TagHotkeyProperty.java
@@ -99,7 +99,7 @@ public class TagHotkeyProperty extends KeyStrokeProperty {
 
     /**
      * We need to completely override the parent class's method here to return
-     * our own TagHokeyField instead of a KeyStrokeField.
+     * our own TagHotkeyField instead of a KeyStrokeField.
      * <p>
      * The returned field is equipped with a built-in FieldValidator
      * to ensure that the value is valid, and that the selected hotkey

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/formfield/TagHotkeyProperty.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/formfield/TagHotkeyProperty.java
@@ -1,0 +1,140 @@
+package ca.corbett.imageviewer.extensions.ice.ui.formfield;
+
+import ca.corbett.extras.properties.KeyStrokeProperty;
+import ca.corbett.extras.properties.Properties;
+import ca.corbett.forms.fields.FormField;
+import ca.corbett.imageviewer.extensions.ice.TagList;
+import ca.corbett.imageviewer.extensions.ice.actions.TagHotkeyAction;
+
+import javax.swing.KeyStroke;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * This property extends KeyStrokeProperty to add support for
+ * associating a TagList with the hotkey. This allows users
+ * to define hotkeys that apply specific tags to images.
+ * <p>
+ * The associated TagList is persisted along with the keystroke
+ * when saving/loading the property to/from Properties.
+ * </p>
+ * <p>
+ * All of the parent class's functionality is preserved, including
+ * support for reserved keystrokes and generating a FormField for
+ * editing the keystroke. However, we override the FormField generation
+ * methods to use our custom TagHotkeyField instead of a KeyStrokeField,
+ * so that both the keystroke and tag list can be edited together.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since 3.0.0
+ */
+public class TagHotkeyProperty extends KeyStrokeProperty {
+
+    private static final Logger log = Logger.getLogger(TagHotkeyProperty.class.getName());
+    private final TagHotkeyAction hotkeyAction;
+
+    /**
+     * Creates a new TagHotkeyProperty with the given name and label, and no initial keystroke.
+     * The associated TagList will be empty initially.
+     */
+    public TagHotkeyProperty(String fullyQualifiedName, String label) {
+        this(fullyQualifiedName, label, null);
+    }
+
+    /**
+     * Creates a new TagHotkeyProperty with the given name, label, and initial keystroke.
+     * The associated TagList will be empty initially.
+     */
+    public TagHotkeyProperty(String fullyQualifiedName, String label, KeyStroke keyStroke) {
+        super(fullyQualifiedName, label, keyStroke, new TagHotkeyAction(label));
+        hotkeyAction = (TagHotkeyAction)getAction();
+    }
+
+    /**
+     * Sets the list of tags to be used in this field, given a tag list string.
+     */
+    public TagHotkeyProperty setTagList(String tagListString) {
+        hotkeyAction.setTagList(TagList.of(tagListString));
+        return this;
+    }
+
+    /**
+     * Sets the list of tags to be used in this field.
+     */
+    public TagHotkeyProperty setTagList(TagList tagList) {
+        hotkeyAction.setTagList(tagList);
+        return this;
+    }
+
+    /**
+     * Returns the tag list being used in this field. May be empty.
+     */
+    public TagList getTagList() {
+        return hotkeyAction.getTagList();
+    }
+
+    /**
+     * We override this to also save our tag list along with the keystroke.
+     */
+    @Override
+    public void saveToProps(Properties props) {
+        super.saveToProps(props); // Save our keystroke and reserved keystrokes
+
+        // Also save our tag list:
+        props.setString(getFullyQualifiedName() + ".tags", getTagList().toString());
+    }
+
+    /**
+     * We override this to also load our tag list along with the keystroke.
+     */
+    @Override
+    public void loadFromProps(Properties props) {
+        super.loadFromProps(props); // Load our keystroke and reserved keystrokes
+
+        // Also load our tag list:
+        String tagListString = props.getString(getFullyQualifiedName() + ".tags", getTagList().toString());
+        setTagList(TagList.of(tagListString));
+    }
+
+    /**
+     * We need to completely override the parent class's method here to return
+     * our own TagHokeyField instead of a KeyStrokeField.
+     * <p>
+     * The returned field is equipped with a built-in FieldValidator
+     * to ensure that the value is valid, and that the selected hotkey
+     * is not on the reserved list.
+     * </p>
+     *
+     * @return A TagHotkeyField with our keystroke and tag list set.
+     */
+    @Override
+    public FormField generateFormFieldImpl() {
+        TagHotkeyField field = new TagHotkeyField(propertyLabel);
+        field.setKeyStroke(getKeyStroke());
+        field.setTagList(getTagList());
+        field.setReservedKeyStrokes(getReservedKeyStrokes());
+        field.setReservedKeyStrokeMsg(getReservedKeyStrokeMsg());
+        return field;
+    }
+
+    /**
+     * We need to completely override the parent class's method here to
+     * extract both the keystroke and tag list from our TagHotkeyField.
+     *
+     * @param field The TagHotkeyField containing a value for this property.
+     */
+    @Override
+    public void loadFromFormField(FormField field) {
+        if (field.getIdentifier() == null
+                || !field.getIdentifier().equals(fullyQualifiedName)
+                || !(field instanceof TagHotkeyField hotkeyField)) {
+            log.log(Level.SEVERE, "TagHotkeyProperty.loadFromFormField: received the wrong field \"{0}\"",
+                    field.getIdentifier());
+            return;
+        }
+
+        setKeyStroke(hotkeyField.getKeyStroke());
+        setTagList(hotkeyField.getTagList());
+    }
+}

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
@@ -5,6 +5,7 @@ Version 3.0.0 [TODO - release date]
   #43 - Ensure TagPreviewPanel shows correct shortcut
   #40 - Upgrade to ImageViewer 3.0 (major update!)
   #39 - Persist left/right quick tag panels separately
+  #32 - Add configurable hotkeys for commonly-used tags
 
 Version 2.4.0 [2026-01-26]
   #34 - Add "Tag directory stats" dialog in filesystem mode

--- a/src/test/java/ca/corbett/imageviewer/extensions/ice/TagListTest.java
+++ b/src/test/java/ca/corbett/imageviewer/extensions/ice/TagListTest.java
@@ -180,4 +180,119 @@ class TagListTest {
         // THEN we should see the replacement worked:
         assertEquals("hello, there, done!", tagList.toString());
     }
+
+    @Test
+    public void isValidNonEmptyTagString_withNull_shouldReturnFalse() {
+        // GIVEN a null tag string:
+        String tagString = null;
+
+        // WHEN we validate it:
+        boolean result = TagList.isValidNonEmptyTagString(tagString);
+
+        // THEN it should be invalid:
+        assertFalse(result);
+    }
+
+    @Test
+    public void isValidNonEmptyTagString_withBlankString_shouldReturnFalse() {
+        // GIVEN blank tag strings:
+        String[] blankInputs = {"", "   ", "\t", "\n", "  \t\n  "};
+
+        for (String input : blankInputs) {
+            // WHEN we validate each one:
+            boolean result = TagList.isValidNonEmptyTagString(input);
+
+            // THEN they should all be invalid:
+            assertFalse(result, "Expected blank string '" + input + "' to be invalid");
+        }
+    }
+
+    @Test
+    public void isValidNonEmptyTagString_withValidSingleTag_shouldReturnTrue() {
+        // GIVEN valid single tag strings:
+        String[] validInputs = {"hello", "world", "tag123", "my-tag", "my_tag", "tag.name"};
+
+        for (String input : validInputs) {
+            // WHEN we validate each one:
+            boolean result = TagList.isValidNonEmptyTagString(input);
+
+            // THEN they should all be valid:
+            assertTrue(result, "Expected valid tag '" + input + "' to be valid");
+        }
+    }
+
+    @Test
+    public void isValidNonEmptyTagString_withValidCommaSeparatedTags_shouldReturnTrue() {
+        // GIVEN valid comma-separated tag strings:
+        String[] validInputs = {
+            "hello,world",
+            "tag1,tag2,tag3",
+            "my-tag,your-tag",
+            "a,b,c,d,e"
+        };
+
+        for (String input : validInputs) {
+            // WHEN we validate each one:
+            boolean result = TagList.isValidNonEmptyTagString(input);
+
+            // THEN they should all be valid:
+            assertTrue(result, "Expected valid tags '" + input + "' to be valid");
+        }
+    }
+
+    @Test
+    public void isValidNonEmptyTagString_withLeftBrace_shouldReturnFalse() {
+        // GIVEN tag strings containing left brace:
+        String[] invalidInputs = {"{hello", "hel{lo", "hello{", "{", "tag1,{tag2"};
+
+        for (String input : invalidInputs) {
+            // WHEN we validate each one:
+            boolean result = TagList.isValidNonEmptyTagString(input);
+
+            // THEN they should all be invalid:
+            assertFalse(result, "Expected tag with '{' character '" + input + "' to be invalid");
+        }
+    }
+
+    @Test
+    public void isValidNonEmptyTagString_withRightBrace_shouldReturnFalse() {
+        // GIVEN tag strings containing right brace:
+        String[] invalidInputs = {"}hello", "hel}lo", "hello}", "}", "tag1,tag2}"};
+
+        for (String input : invalidInputs) {
+            // WHEN we validate each one:
+            boolean result = TagList.isValidNonEmptyTagString(input);
+
+            // THEN they should all be invalid:
+            assertFalse(result, "Expected tag with '}' character '" + input + "' to be invalid");
+        }
+    }
+
+    @Test
+    public void isValidNonEmptyTagString_withPipe_shouldReturnFalse() {
+        // GIVEN tag strings containing pipe character:
+        String[] invalidInputs = {"|hello", "hel|lo", "hello|", "|", "tag1,|tag2"};
+
+        for (String input : invalidInputs) {
+            // WHEN we validate each one:
+            boolean result = TagList.isValidNonEmptyTagString(input);
+
+            // THEN they should all be invalid:
+            assertFalse(result, "Expected tag with '|' character '" + input + "' to be invalid");
+        }
+    }
+
+    @Test
+    public void isValidNonEmptyTagString_withMultipleDisallowedChars_shouldReturnFalse() {
+        // GIVEN tag strings containing multiple disallowed characters:
+        String[] invalidInputs = {"{hello}", "{tag1}|{tag2}", "a{b|c}d", "|||{{{}}}"};
+
+        for (String input : invalidInputs) {
+            // WHEN we validate each one:
+            boolean result = TagList.isValidNonEmptyTagString(input);
+
+            // THEN they should all be invalid:
+            assertFalse(result, "Expected tag with multiple disallowed characters '" + input + "' to be invalid");
+        }
+    }
 }


### PR DESCRIPTION
This PR addresses issue #32 by introducing a new feature for the ICE extension - configurable hotkeys for quickly setting a configurable list of tags to the currently selected image. Users can use the application settings dialog to specify the keystroke and the taglist for each of our hotkeys.

Specific changes here:
- introduce a new FormField implementation `TagHotkeyField`
- extend the `KeyStrokeProperty` class to new class `TagHotkeyProperty` to associate a TagList to a KeyStroke.
- Preserve the ability to set reserved keystrokes that cannot be selected by the user.
- Use a very similar swing-extras bug workaround for reserved keystrokes as in the application core code.
- Add 8 hotkey options (arbitrary number, not configurable)
- Add a new `TagHotkeyAction` class to actually set the tag list when invoked, with error checking.