### PR TITLE
Issue #51 - added keyboard shortcuts for quick tag panels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ target/
 *.iws
 *.iml
 *.ipr
+.idea/copilot.*
 
 ### Eclipse ###
 .apt_generated

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
@@ -15,6 +15,9 @@ import ca.corbett.extras.properties.ShortTextProperty;
 import ca.corbett.imageviewer.AppConfig;
 import ca.corbett.imageviewer.ImageOperation;
 import ca.corbett.imageviewer.extensions.ImageViewerExtension;
+import ca.corbett.imageviewer.extensions.ice.actions.QuickTagToggleLeftAction;
+import ca.corbett.imageviewer.extensions.ice.actions.QuickTagToggleLeftRightAction;
+import ca.corbett.imageviewer.extensions.ice.actions.QuickTagToggleRightAction;
 import ca.corbett.imageviewer.extensions.ice.actions.RandomImageSetAction;
 import ca.corbett.imageviewer.extensions.ice.actions.ScanDirAction;
 import ca.corbett.imageviewer.extensions.ice.actions.SearchAction;
@@ -83,8 +86,13 @@ public class IceExtension extends ImageViewerExtension {
     public static final String fontSizeProp = "Thumbnails.Companion files.linkFontSize";
     public static final String quickTagLeftSourceProp = "Hidden.quickTagsLeft.source";
     public static final String quickTagRightSourceProp = "Hidden.quickTagsRight.source";
-    public static final String quickTagShortcutProp = AppConfig.KEYSTROKE_PREFIX + "ICE.quickTagPanel";
+    public static final String imageTagShortcutProp = AppConfig.KEYSTROKE_PREFIX + "ICE.quickTagPanel";
     public static final String tagHotkeyPropPrefix = AppConfig.KEYSTROKE_PREFIX + "ICE.tagHotKey";
+
+    public static final String QUICK_TAG_TOGGLE = AppConfig.KEYSTROKE_PREFIX + "ICE - QuickTag toggles.";
+    public static final String quickTagShortcutLeftProp = QUICK_TAG_TOGGLE + "ICE.quickTagPanelLeft";
+    public static final String quickTagShortcutRightProp = QUICK_TAG_TOGGLE + "ICE.quickTagPanelRight";
+    public static final String quickTagShortcutLeftRightProp = QUICK_TAG_TOGGLE + "ICE.quickTagPanelLeftRight";
 
     private final List<TagPreviewPanel> tagPreviewPanels = new ArrayList<>();
     private final List<QuickTagPanel> quickTagPanels = new ArrayList<>();
@@ -123,9 +131,21 @@ public class IceExtension extends ImageViewerExtension {
                                        QuickTagPanel.DEFAULT_SOURCE_NAME).setExposed(false));
         list.add(new ShortTextProperty(quickTagRightSourceProp, "quickTagsRightSource",
                                        QuickTagPanel.DEFAULT_SOURCE_NAME).setExposed(false));
-        list.add(new KeyStrokeProperty(quickTagShortcutProp, "Image tag dialog:",
+        list.add(new KeyStrokeProperty(imageTagShortcutProp, "Image tag dialog:",
                                        KeyStrokeManager.parseKeyStroke("Ctrl+G"),
                                        TagSingleImageAction.getInstance())
+                         .setAllowBlank(true));
+        list.add(new KeyStrokeProperty(quickTagShortcutLeftProp, "Toggle left position:",
+                                       KeyStrokeManager.parseKeyStroke("alt+shift+left"),
+                                       QuickTagToggleLeftAction.getInstance())
+                         .setAllowBlank(true));
+        list.add(new KeyStrokeProperty(quickTagShortcutRightProp, "Toggle right position:",
+                                       KeyStrokeManager.parseKeyStroke("alt+shift+right"),
+                                       QuickTagToggleRightAction.getInstance())
+                         .setAllowBlank(true));
+        list.add(new KeyStrokeProperty(quickTagShortcutLeftRightProp, "Toggle both positions:",
+                                       KeyStrokeManager.parseKeyStroke("alt+shift+up"),
+                                       QuickTagToggleLeftRightAction.getInstance())
                          .setAllowBlank(true));
 
         // Add a few configurable hotkeys for commonly-used tags:
@@ -209,6 +229,7 @@ public class IceExtension extends ImageViewerExtension {
     public JComponent getExtraPanelComponent(ExtraPanelPosition position) {
         if (position == getTagPreviewPositionFromConfig()) {
             TagPreviewPanel tagPreviewPanel = new TagPreviewPanel(); // create a new one for each request... other extensions may ask for it
+            tagPreviewPanel.setName("ICE"); // short name in case our component gets added to a tab pane
             tagPreviewPanels.add(tagPreviewPanel);
             return tagPreviewPanel;
         }
@@ -219,6 +240,7 @@ public class IceExtension extends ImageViewerExtension {
             JScrollPane scrollPane = new JScrollPane(panel);
             scrollPane.getVerticalScrollBar().setUnitIncrement(10);
             scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+            scrollPane.setName("ICE"); // short name in case our component gets added to a tab pane
             return scrollPane;
         }
 

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
@@ -90,9 +90,9 @@ public class IceExtension extends ImageViewerExtension {
     public static final String tagHotkeyPropPrefix = AppConfig.KEYSTROKE_PREFIX + "ICE.tagHotKey";
 
     public static final String QUICK_TAG_TOGGLE = AppConfig.KEYSTROKE_PREFIX + "ICE - QuickTag toggles.";
-    public static final String quickTagShortcutLeftProp = QUICK_TAG_TOGGLE + "ICE.quickTagPanelLeft";
-    public static final String quickTagShortcutRightProp = QUICK_TAG_TOGGLE + "ICE.quickTagPanelRight";
-    public static final String quickTagShortcutLeftRightProp = QUICK_TAG_TOGGLE + "ICE.quickTagPanelLeftRight";
+    public static final String quickTagShortcutLeftProp = QUICK_TAG_TOGGLE + "quickTagPanelLeft";
+    public static final String quickTagShortcutRightProp = QUICK_TAG_TOGGLE + "quickTagPanelRight";
+    public static final String quickTagShortcutLeftRightProp = QUICK_TAG_TOGGLE + "quickTagPanelLeftRight";
 
     private final List<TagPreviewPanel> tagPreviewPanels = new ArrayList<>();
     private final List<QuickTagPanel> quickTagPanels = new ArrayList<>();

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/QuickTagToggleLeftAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/QuickTagToggleLeftAction.java
@@ -1,0 +1,73 @@
+package ca.corbett.imageviewer.extensions.ice.actions;
+
+import ca.corbett.extras.EnhancedAction;
+import ca.corbett.extras.properties.AbstractProperty;
+import ca.corbett.extras.properties.ComboProperty;
+import ca.corbett.imageviewer.AppConfig;
+import ca.corbett.imageviewer.extensions.ice.IceExtension;
+import ca.corbett.imageviewer.ui.MainWindow;
+import ca.corbett.imageviewer.ui.actions.ReloadUIAction;
+
+import java.awt.event.ActionEvent;
+
+/**
+ * An action to toggle the visibility of the quick tag panel on the left side.
+ * If the left panel is currently visible, it will be hidden; if it is hidden, it will be shown.
+ * If there is a quick tag panel also in the right position, it will remain visible.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since 3.0.0
+ */
+public class QuickTagToggleLeftAction extends EnhancedAction {
+
+    private static QuickTagToggleLeftAction instance;
+
+    private QuickTagToggleLeftAction() {
+        super("Quick tag toggle left");
+    }
+
+    public static QuickTagToggleLeftAction getInstance() {
+        if (instance == null) {
+            instance = new QuickTagToggleLeftAction();
+        }
+        return instance;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        // Get the property that controls quick tag panel position:
+        AbstractProperty prop = AppConfig
+                .getInstance()
+                .getPropertiesManager()
+                .getProperty(IceExtension.quickTagPanelPositionProp);
+
+        if (prop instanceof ComboProperty<?> comboProp) {
+            // Option indexes:
+            //   0 == hidden
+            //   1 == left
+            //   2 == right
+            //   3 == both left and right
+            //
+            // Basically, if left was showing, hide it, otherwise show it:
+            int newIndex = switch (comboProp.getSelectedIndex()) {
+                case 0 -> 1; // hidden -> left
+                case 1 -> 0; // left -> hidden
+                case 2 -> 3; // right -> both
+                case 3 -> 2; // both -> right
+                default -> 0; // should not happen
+            };
+
+            comboProp.setSelectedIndex(newIndex);
+            AppConfig.getInstance().save(); // force silent save to persist this immediately
+
+            // It may seem like overkill to reload the entire UI just to hide these panels,
+            // but the main image view needs to be laid out again as a result of this change.
+            ReloadUIAction.getInstance().actionPerformed(null);
+        }
+
+        // Should never happen...
+        else {
+            MainWindow.getInstance().showMessageDialog("Internal Error", "Configuration property type mismatch.");
+        }
+    }
+}

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/QuickTagToggleLeftRightAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/QuickTagToggleLeftRightAction.java
@@ -11,8 +11,9 @@ import ca.corbett.imageviewer.ui.actions.ReloadUIAction;
 import java.awt.event.ActionEvent;
 
 /**
- * An action to toggle the visibility of the quick tag panels on both sides.
- * If either panel is currently visible, it will be hidden; if both are hidden, both will be shown.
+ * An action to toggle the visibility of the quick tag panels by inverting the current layout.
+ * If panels are hidden, both are shown; if only the left is shown, it switches to right; if only
+ * the right is shown, it switches to left; and if both are shown, both are hidden.
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  * @since 3.0.0

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/QuickTagToggleLeftRightAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/QuickTagToggleLeftRightAction.java
@@ -1,0 +1,72 @@
+package ca.corbett.imageviewer.extensions.ice.actions;
+
+import ca.corbett.extras.EnhancedAction;
+import ca.corbett.extras.properties.AbstractProperty;
+import ca.corbett.extras.properties.ComboProperty;
+import ca.corbett.imageviewer.AppConfig;
+import ca.corbett.imageviewer.extensions.ice.IceExtension;
+import ca.corbett.imageviewer.ui.MainWindow;
+import ca.corbett.imageviewer.ui.actions.ReloadUIAction;
+
+import java.awt.event.ActionEvent;
+
+/**
+ * An action to toggle the visibility of the quick tag panels on both sides.
+ * If either panel is currently visible, it will be hidden; if both are hidden, both will be shown.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since 3.0.0
+ */
+public class QuickTagToggleLeftRightAction extends EnhancedAction {
+
+    private static QuickTagToggleLeftRightAction instance;
+
+    private QuickTagToggleLeftRightAction() {
+        super("Quick tag toggle left+right");
+    }
+
+    public static QuickTagToggleLeftRightAction getInstance() {
+        if (instance == null) {
+            instance = new QuickTagToggleLeftRightAction();
+        }
+        return instance;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        // Get the property that controls quick tag panel position:
+        AbstractProperty prop = AppConfig
+                .getInstance()
+                .getPropertiesManager()
+                .getProperty(IceExtension.quickTagPanelPositionProp);
+
+        if (prop instanceof ComboProperty<?> comboProp) {
+            // Option indexes:
+            //   0 == hidden
+            //   1 == left
+            //   2 == right
+            //   3 == both left and right
+            //
+            // Basically, invert whatever is showing:
+            int newIndex = switch (comboProp.getSelectedIndex()) {
+                case 0 -> 3; // hidden -> both
+                case 1 -> 2; // left -> right
+                case 2 -> 1; // right -> left
+                case 3 -> 0; // both -> none
+                default -> 0; // should not happen
+            };
+
+            comboProp.setSelectedIndex(newIndex);
+            AppConfig.getInstance().save(); // force silent save to persist this immediately
+
+            // It may seem like overkill to reload the entire UI just to hide these panels,
+            // but the main image view needs to be laid out again as a result of this change.
+            ReloadUIAction.getInstance().actionPerformed(null);
+        }
+
+        // Should never happen...
+        else {
+            MainWindow.getInstance().showMessageDialog("Internal Error", "Configuration property type mismatch.");
+        }
+    }
+}

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/QuickTagToggleRightAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/QuickTagToggleRightAction.java
@@ -1,0 +1,73 @@
+package ca.corbett.imageviewer.extensions.ice.actions;
+
+import ca.corbett.extras.EnhancedAction;
+import ca.corbett.extras.properties.AbstractProperty;
+import ca.corbett.extras.properties.ComboProperty;
+import ca.corbett.imageviewer.AppConfig;
+import ca.corbett.imageviewer.extensions.ice.IceExtension;
+import ca.corbett.imageviewer.ui.MainWindow;
+import ca.corbett.imageviewer.ui.actions.ReloadUIAction;
+
+import java.awt.event.ActionEvent;
+
+/**
+ * An action to toggle the visibility of the quick tag panel on the right side.
+ * If the right panel is currently visible, it will be hidden; if it is hidden, it will be shown.
+ * If there is a quick tag panel also in the left position, it will remain visible.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since 3.0.0
+ */
+public class QuickTagToggleRightAction extends EnhancedAction {
+
+    private static QuickTagToggleRightAction instance;
+
+    private QuickTagToggleRightAction() {
+        super("Quick tag toggle right");
+    }
+
+    public static QuickTagToggleRightAction getInstance() {
+        if (instance == null) {
+            instance = new QuickTagToggleRightAction();
+        }
+        return instance;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        // Get the property that controls quick tag panel position:
+        AbstractProperty prop = AppConfig
+                .getInstance()
+                .getPropertiesManager()
+                .getProperty(IceExtension.quickTagPanelPositionProp);
+
+        if (prop instanceof ComboProperty<?> comboProp) {
+            // Option indexes:
+            //   0 == hidden
+            //   1 == left
+            //   2 == right
+            //   3 == both left and right
+            //
+            // Basically, if right was showing, hide it, otherwise show it:
+            int newIndex = switch (comboProp.getSelectedIndex()) {
+                case 0 -> 2; // hidden -> right
+                case 2 -> 0; // right -> hidden
+                case 1 -> 3; // left -> both
+                case 3 -> 1; // both -> left
+                default -> 0; // should not happen
+            };
+
+            comboProp.setSelectedIndex(newIndex);
+            AppConfig.getInstance().save(); // force silent save to persist this immediately
+
+            // It may seem like overkill to reload the entire UI just to hide these panels,
+            // but the main image view needs to be laid out again as a result of this change.
+            ReloadUIAction.getInstance().actionPerformed(null);
+        }
+
+        // Should never happen...
+        else {
+            MainWindow.getInstance().showMessageDialog("Internal Error", "Configuration property type mismatch.");
+        }
+    }
+}

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/TagPreviewPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/TagPreviewPanel.java
@@ -62,7 +62,7 @@ public class TagPreviewPanel extends JPanel {
         // Try to get it from AppConfig first:
         // (This is the normal case, after initial startup)
         AbstractProperty prop = AppConfig.getInstance().getPropertiesManager()
-                                         .getProperty(IceExtension.quickTagShortcutProp);
+                                         .getProperty(IceExtension.imageTagShortcutProp);
         if (prop != null) {
             ks = ((KeyStrokeProperty)prop).getKeyStroke();
         }
@@ -72,7 +72,7 @@ public class TagPreviewPanel extends JPanel {
         // into AppConfig's persistent storage. This feels a bit hacky, but it *should* only happen once on startup.
         else {
             String keystrokeStr = AppConfig.peek(Version.APP_CONFIG_FILE,
-                                                 IceExtension.quickTagShortcutProp + ".keyStroke");
+                                                 IceExtension.imageTagShortcutProp + ".keyStroke");
             // It may legitimately be null here, if the user has unassigned the shortcut:
             // (or if this is a first run on a brand-new install, but that will fix itself on second run)
             // (yeah, this feels hacky too, but oh well)

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
@@ -2,6 +2,7 @@ ext-iv-ice Release Notes
 Author: Steve Corbett
 
 Version 3.0.0 [TODO - release date]
+  #51 - Add keyboard shortcuts for quick tag panels
   #43 - Ensure TagPreviewPanel shows correct shortcut
   #40 - Upgrade to ImageViewer 3.0 (major update!)
   #39 - Persist left/right quick tag panels separately


### PR DESCRIPTION
This PR addresses issue #51 by adding additional keyboard shortcuts to toggle the visibility of the two quicktag panels - one in the left position, one in the right position. The shortcuts intelligently invert the visibility status of the panel in the given position.

Also renamed an unrelated shortcut from `quickTagShortcutProp` to `imageTagShortcutProp` - the original name was confusing, as that shortcut has nothing to do with the quick tag panels.
