### PR TITLE
Issue #54 - SearchDialog: add sort options

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/threads/SearchThread.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/threads/SearchThread.java
@@ -88,7 +88,7 @@ public class SearchThread extends MultiProgressWorker {
     public List<File> getSearchResults(SortMode sortMode) {
         // If the search found nothing, sorting is irrelevant:
         if (searchResults.isEmpty()) {
-            return searchResults;
+            return new ArrayList<>(searchResults);
         }
 
         // Otherwise, apply sort mode:

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/threads/SearchThread.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/threads/SearchThread.java
@@ -10,6 +10,7 @@ import org.apache.commons.io.FilenameUtils;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -23,6 +24,32 @@ import java.util.logging.Logger;
 public class SearchThread extends MultiProgressWorker {
 
     private static final Logger log = Logger.getLogger(SearchThread.class.getName());
+
+    /**
+     * Describes options for determining the sort order of the result set.
+     */
+    public enum SortMode {
+        FOUND_ORDER_ASCENDING("Found order, ascending"),
+        FOUND_ORDER_DESCENDING("Found order, descending"),
+        FILENAME_ASCENDING("By filename, ascending"),
+        FILENAME_DESCENDING("By filename, descending"),
+        PATH_ASCENDING("By file path/name, ascending"),
+        PATH_DESCENDING("By file path/name, descending"),
+        DATE_ASCENDING("By file date, ascending"),
+        DATE_DESCENDING("By file date, descending"),
+        RANDOM("Random order");
+
+        private final String label;
+
+        SortMode(String label) {
+            this.label = label;
+        }
+
+        @Override
+        public String toString() {
+            return label;
+        }
+    }
 
     private final File initialDir;
     private final boolean isRecursive;
@@ -55,8 +82,48 @@ public class SearchThread extends MultiProgressWorker {
         wasCanceled = false;
     }
 
-    public List<File> getSearchResults() {
-        return new ArrayList<>(searchResults);
+    /**
+     * Returns the result set of this search, using the given SortMode to order them.
+     */
+    public List<File> getSearchResults(SortMode sortMode) {
+        // If the search found nothing, sorting is irrelevant:
+        if (searchResults.isEmpty()) {
+            return searchResults;
+        }
+
+        // Otherwise, apply sort mode:
+        List<File> sortedResults = new ArrayList<>(searchResults);
+        switch (sortMode) {
+            case FOUND_ORDER_ASCENDING:
+                // No sorting needed, already in found order
+                break;
+            case FOUND_ORDER_DESCENDING:
+                Collections.reverse(sortedResults);
+                break;
+            case FILENAME_ASCENDING:
+                sortedResults.sort((f1, f2) -> f1.getName().compareToIgnoreCase(f2.getName()));
+                break;
+            case FILENAME_DESCENDING:
+                sortedResults.sort((f1, f2) -> f2.getName().compareToIgnoreCase(f1.getName()));
+                break;
+            case PATH_ASCENDING:
+                sortedResults.sort((f1, f2) -> f1.getAbsolutePath().compareToIgnoreCase(f2.getAbsolutePath()));
+                break;
+            case PATH_DESCENDING:
+                sortedResults.sort((f1, f2) -> f2.getAbsolutePath().compareToIgnoreCase(f1.getAbsolutePath()));
+                break;
+            case DATE_ASCENDING:
+                sortedResults.sort((f1, f2) -> Long.compare(f1.lastModified(), f2.lastModified()));
+                break;
+            case DATE_DESCENDING:
+                sortedResults.sort((f1, f2) -> Long.compare(f2.lastModified(), f1.lastModified()));
+                break;
+            case RANDOM:
+                Collections.shuffle(sortedResults);
+                break;
+        }
+
+        return sortedResults;
     }
 
     public boolean wasCanceled() {

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/SearchDialog.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/SearchDialog.java
@@ -27,10 +27,32 @@ import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.logging.Logger;
 
+/**
+ * Presents a dialog for searching images based on their tags.
+ * This dialog works in both filesystem mode and in ImageSet mode.
+ * In filesystem mode, you can specify a directory with optional recursion.
+ * In ImageSet mode, you can specify which image sets to search through.
+ * <p>
+ * <b>Specifying search parameters</b> - You can fill in <b>at least one</b>
+ * of the following tag fields:
+ * </p>
+ * <ul>
+ *     <li><b>ALL of these tags</b> candidate images must contain all specified tags in order to match.</li>
+ *     <li><b>ANY of these tags</b> candidate images must contain at least one of the specified tags in order to match.</li>
+ *     <li><b>NONE of these tags</b> candidate images must not contain any of the specified tags in order to match.</li>
+ * </ul>
+ * <p>
+ *     <b>Controlling sort order</b> - by default, search results are returned in whatever
+ *     order they are found. You can use the "sort search results by" dropdown to specify a different sort order.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
 public class SearchDialog extends JDialog {
 
     private static final Logger log = Logger.getLogger(SearchDialog.class.getName());
@@ -53,6 +75,7 @@ public class SearchDialog extends JDialog {
     private ShortTextField tagFieldAll;
     private ShortTextField tagFieldAny;
     private ShortTextField tagFieldNone;
+    private ComboField<SearchThread.SortMode> sortModeField;
 
     public SearchDialog() {
         this("Search");
@@ -60,7 +83,7 @@ public class SearchDialog extends JDialog {
 
     public SearchDialog(String title) {
         super(MainWindow.getInstance(), title, true);
-        setSize(new Dimension(630, 400));
+        setSize(new Dimension(630, 440));
         setResizable(false);
         setLocationRelativeTo(MainWindow.getInstance());
         setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
@@ -81,7 +104,8 @@ public class SearchDialog extends JDialog {
 
             @Override
             public void progressComplete() {
-                handleSearchComplete(searchThread.wasCanceled(), searchThread.getSearchResults());
+                SearchThread.SortMode sortMode = sortModeField.getSelectedItem();
+                handleSearchComplete(searchThread.wasCanceled(), searchThread.getSearchResults(sortMode));
             }
         });
         progressDialog.runWorker(searchThread, true);
@@ -176,6 +200,11 @@ public class SearchDialog extends JDialog {
         tagFieldNone.addFieldValidator(new TagFieldValidator());
         formPanel.add(tagFieldNone);
         formPanel.add(LabelField.createPlainHeaderLabel("(fill in at least one)"));
+
+        sortModeField = new ComboField<>("Sort search results by:",
+                                         Arrays.asList(SearchThread.SortMode.values()), 0);
+        sortModeField.getMargins().setTop(12);
+        formPanel.add(sortModeField);
 
         return formPanel;
     }

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
@@ -5,6 +5,7 @@ Version 3.0.0 [TODO - release date]
   #61 - Respond to ActionPanel events for quick tag edits
   #59 - Now using ActionPanel for quick tags panel
   #57 - ImageViewer has upgraded to swing-extras 2.8
+  #54 - Search: add sort options
   #51 - Add keyboard shortcuts for quick tag panels
   #43 - Ensure TagPreviewPanel shows correct shortcut
   #40 - Upgrade to ImageViewer 3.0 (major update!)


### PR DESCRIPTION
This PR addresses issue #54 by adding sort options to the Search dialog. The default selection for the new sort mode option is "found order, ascending", which matches the previous behavior. 