### PR TITLE
Issue #55 - fix missing progress bar in random set dialog

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/RandomImageSetDialog.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/RandomImageSetDialog.java
@@ -13,7 +13,6 @@ import ca.corbett.forms.fields.LabelField;
 import ca.corbett.forms.fields.NumberField;
 import ca.corbett.imageviewer.extensions.ice.TagList;
 import ca.corbett.imageviewer.ui.MainWindow;
-import ca.corbett.imageviewer.ui.ThumbContainerPanel;
 import ca.corbett.imageviewer.ui.imagesets.ImageSet;
 import ca.corbett.imageviewer.ui.imagesets.ImageSetManager;
 import org.apache.commons.io.FilenameUtils;
@@ -139,7 +138,6 @@ public class RandomImageSetDialog extends JDialog {
         // Fire off a worker thread as the scan may take some time:
         boolean isRecursive = recursiveField.isChecked();
         MultiProgressDialog progressDialog = new MultiProgressDialog(this, "Scanning directory...");
-        progressDialog.setInitialShowDelayMS(500);
         progressDialog.runWorker(new RandomImageSetDialog.ScanWorker(directory, isRecursive), true);
     }
 
@@ -335,10 +333,24 @@ public class RandomImageSetDialog extends JDialog {
             int taggedCount = 0;
             int untaggedCount = 0;
 
+            // Enumerating all files is crazy slow on large directories, particularly
+            // on machines with mechanical hard drives. This is a problem, because
+            // our progress dialog won't show up until we invoke fireProgressBegins(),
+            // and we can't properly invoke that until we know how many files we have to process.
+            // So, let's fire progressBegins with a dummy step count, just to get the
+            // dialog to show up. This gives the user visual feedback that we are working:
+            fireProgressBegins(1);
+
+            // Now do the heavy work. Our progress dialog is visible at this point, unless
+            // the caller set an initial show delay. Not much we can do in that case.
             List<File> allFiles = FileSystemUtil.findFiles(dir, recursive)
                                                 .stream()
                                                 .filter(ImageUtil::isImageFile)
                                                 .toList();
+
+            // Now we can set our progress bar bounds with actual values:
+            // This does mean that callers get two "progress begins" events, but that's
+            // better than the alternative of having no progress dialog at all for long-running scans:
             fireProgressBegins(allFiles.size());
 
             try {

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
@@ -5,6 +5,7 @@ Version 3.0.0 [TODO - release date]
   #61 - Respond to ActionPanel events for quick tag edits
   #59 - Now using ActionPanel for quick tags panel
   #57 - ImageViewer has upgraded to swing-extras 2.8
+  #55 - RandomImageSetDialog: fix missing progress bar
   #54 - Search: add sort options
   #51 - Add keyboard shortcuts for quick tag panels
   #43 - Ensure TagPreviewPanel shows correct shortcut


### PR DESCRIPTION
This PR addresses issue #55 by fixing a problem in the RandomImageSetDialog where the progress bar would not become visible for sometimes up to several seconds after the dialog is shown, giving the impression that it is not scanning anything.

The problem is that the progress dialog can't be shown until the number of steps is known (so that the progress bar bounds can be set). But, we don't know the number of steps until we have enumerated all files in the given scan directory, which can take quite some time with larger directories on older machines, or on machines with mechanical hard drives.

So, the creative workaround is to immediately fire `progressBegins` with a dummy count of steps, just to cause the progress dialog to show up immediately, and then invoke `progressBegins` again once the actual count of steps is known. There are two drawbacks to this approach:

- listeners now receive two `progressBegins` events instead of one, which might be confusing. Not really a concern in our case.
- The `initialShowDelay` for the progress dialog had to be removed. So, even for very quick scans, the progress dialog will quickly appear and then disappear. This seems unavoidable, because we can't check for `initialShowDelay` while we are I/O blocked waiting for a filesystem enumeration to complete. An acceptable compromise, in my opinion.
