### PR TITLE
Issue #56 - fix bad tag preview panel alignment

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/TagPreviewPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/TagPreviewPanel.java
@@ -18,12 +18,14 @@ import ca.corbett.imageviewer.ui.MainWindow;
 import javax.swing.JPanel;
 import javax.swing.KeyStroke;
 import java.awt.BorderLayout;
-import java.awt.Color;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 
 /**
  * Represents a read-only panel for displaying tags for the current image.
+ * Clicking on the text field will open the tag dialog for the current image.
+ * The help label for the text field will show the currently-configured keyboard shortcut
+ * for the tag dialog, if there is one.
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  */
@@ -32,23 +34,14 @@ public class TagPreviewPanel extends JPanel {
 
     public TagPreviewPanel() {
         setLayout(new BorderLayout());
-        FormPanel formPanel = new FormPanel(Alignment.TOP_LEFT);
-        formPanel.setBorderMargin(6);
+        FormPanel formPanel = new FormPanel(Alignment.CENTER);
+        formPanel.setBorderMargin(4);
+        formPanel.setBackground(AppConfig.getInstance().getDefaultBackground());
         textField = LongTextField.ofDynamicSizingMultiLine("", 1);
         textField.setMargins(new Margins(10, 4, 10, 4, 0));
         textField.setEnabled(false);
-        this.setBackground(Color.GREEN);
-        textField.getTextArea().setColumns(10); // dumb! remove once swing-extras #119 fix is available in 2.5 release
         textField.setHelpText(getHelpText());
-        textField.getTextArea().addMouseListener(new MouseAdapter() {
-            @Override
-            public void mouseClicked(MouseEvent e) {
-                ImageInstance currentImage = MainWindow.getInstance().getSelectedImage();
-                if (! currentImage.isEmpty()) {
-                    TagSingleImageAction.getInstance().actionPerformed(null);
-                }
-            }
-        });
+        textField.getTextArea().addMouseListener(new TagFieldMouseListener());
         formPanel.add(textField);
         add(formPanel, BorderLayout.CENTER);
     }
@@ -94,5 +87,20 @@ public class TagPreviewPanel extends JPanel {
 
     public void setTagList(TagList tagList) {
         textField.setText(tagList.toString());
+    }
+
+    /**
+     * A very simple mouse listener to execute our TagSingleImageAction when the user clicks on the tag preview.
+     * This is just a convenient shortcut to open the tag dialog for the current image, since the tag preview is
+     * read-only and doesn't have any other interactivity.
+     */
+    private static class TagFieldMouseListener extends MouseAdapter {
+        @Override
+        public void mouseClicked(MouseEvent e) {
+            ImageInstance currentImage = MainWindow.getInstance().getSelectedImage();
+            if (!currentImage.isEmpty()) {
+                TagSingleImageAction.getInstance().actionPerformed(null);
+            }
+        }
     }
 }

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
@@ -5,6 +5,7 @@ Version 3.0.0 [TODO - release date]
   #61 - Respond to ActionPanel events for quick tag edits
   #59 - Now using ActionPanel for quick tags panel
   #57 - ImageViewer has upgraded to swing-extras 2.8
+  #56 - Fix bad alignment of tag preview panel
   #55 - RandomImageSetDialog: fix missing progress bar
   #54 - Search: add sort options
   #51 - Add keyboard shortcuts for quick tag panels


### PR DESCRIPTION
This PR addresses issue #56 by making some minor cosmetic adjustments to the tag preview panel. There were actually several minor problems:

- alignment was to the left, but should have been centered
- hard-coded background color (invisible because it was set on the wrong component anyway)
- preview panel itself was not respecting the user-configured background color
- old workaround code still present from a much earlier version of the swing-extras dependency - removed it.
- ugly use of inline class for listening for mouse events
- poor/incomplete class-level Javadocs
