### PR TITLE
Issue #66 - fix missing scrollbar in quick tag panel

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
@@ -31,6 +31,8 @@ import ca.corbett.imageviewer.extensions.ice.ui.formfield.TagHotkeyProperty;
 import ca.corbett.imageviewer.ui.ImageInstance;
 import ca.corbett.imageviewer.ui.MainWindow;
 import ca.corbett.imageviewer.ui.ThumbPanel;
+import ca.corbett.imageviewer.ui.UIReloadable;
+import ca.corbett.imageviewer.ui.actions.ReloadUIAction;
 import org.apache.commons.io.FilenameUtils;
 
 import javax.swing.JComponent;
@@ -60,7 +62,7 @@ import java.util.logging.Logger;
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  */
-public class IceExtension extends ImageViewerExtension {
+public class IceExtension extends ImageViewerExtension implements UIReloadable {
 
     private static final Logger log = Logger.getLogger(IceExtension.class.getName());
 
@@ -178,11 +180,13 @@ public class IceExtension extends ImageViewerExtension {
     @Override
     public void onActivate() {
         TagIndex.getInstance().load();
+        ReloadUIAction.getInstance().registerReloadable(this);
     }
 
     @Override
     public void onDeactivate() {
         TagIndex.getInstance().save();
+        ReloadUIAction.getInstance().unregisterReloadable(this);
     }
 
     /**
@@ -497,4 +501,10 @@ public class IceExtension extends ImageViewerExtension {
         return label;
     }
 
+    @Override
+    public void reloadUI() {
+        for (QuickTagPanel panel : quickTagPanels) {
+            panel.refreshPreferredWidth(); // user may have changed the preferred quick panel width
+        }
+    }
 }

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
@@ -36,7 +36,6 @@ import org.apache.commons.io.FilenameUtils;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JScrollPane;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Cursor;
@@ -243,11 +242,8 @@ public class IceExtension extends ImageViewerExtension {
         if (getQuickTagPositionFromConfig().contains(position)) {
             QuickTagPanel panel = new QuickTagPanel(position); // create a new one on each request
             quickTagPanels.add(panel);
-            JScrollPane scrollPane = new JScrollPane(panel);
-            scrollPane.getVerticalScrollBar().setUnitIncrement(10);
-            scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-            scrollPane.setName("ICE"); // short name in case our component gets added to a tab pane
-            return scrollPane;
+            panel.setName("ICE"); // short name in case our component gets added to a tab pane
+            return panel;
         }
 
         return null;

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
@@ -88,6 +88,8 @@ public class QuickTagPanel extends JPanel {
     // Size for all icons in our ActionPanel:
     private static final int iconSize = 18;
 
+    private int preferredPanelWidth = 200; // customized via AppConfig
+
     private final ImageViewerExtension.ExtraPanelPosition position;
     private final ActionPanel actionPanel;
     private final File sourceRootDir;
@@ -118,6 +120,7 @@ public class QuickTagPanel extends JPanel {
         this.tagListsByName = new HashMap<>();
         this.actionPanel = buildActionPanel();
 
+        refreshPreferredWidth();
         setLayout(new BorderLayout());
         JScrollPane scrollPane = ScrollUtil.buildScrollPane(actionPanel, 10);
         scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
@@ -128,6 +131,18 @@ public class QuickTagPanel extends JPanel {
         }
 
         reset(); // Force a load of our contents
+    }
+
+    /**
+     * Looks up the currently-configured preferred width for quick tag panels
+     * from application settings and updates the instance variable.
+     */
+    public void refreshPreferredWidth() {
+        IntegerProperty prop = (IntegerProperty)AppConfig
+                .getInstance()
+                .getPropertiesManager()
+                .getProperty(IceExtension.quickTagPanelWidthProp);
+        preferredPanelWidth = prop == null ? 200 : prop.getValue();
     }
 
     /**
@@ -232,13 +247,8 @@ public class QuickTagPanel extends JPanel {
         ActionPanel actionPanel = new ActionPanel() {
             @Override
             public Dimension getPreferredSize() {
-                IntegerProperty prop = (IntegerProperty)AppConfig
-                        .getInstance()
-                        .getPropertiesManager()
-                        .getProperty(IceExtension.quickTagPanelWidthProp);
-                int panelWidth = prop == null ? 200 : prop.getValue();
                 Dimension superPref = super.getPreferredSize();
-                return new Dimension(panelWidth, superPref.height);
+                return new Dimension(preferredPanelWidth, superPref.height);
             }
         };
 

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
@@ -1,6 +1,7 @@
 package ca.corbett.imageviewer.extensions.ice.ui;
 
 import ca.corbett.extras.EnhancedAction;
+import ca.corbett.extras.ScrollUtil;
 import ca.corbett.extras.TextInputDialog;
 import ca.corbett.extras.actionpanel.ActionComponentType;
 import ca.corbett.extras.actionpanel.ActionPanel;
@@ -29,6 +30,7 @@ import org.apache.commons.io.FilenameUtils;
 import javax.swing.ImageIcon;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
@@ -117,7 +119,9 @@ public class QuickTagPanel extends JPanel {
         this.actionPanel = buildActionPanel();
 
         setLayout(new BorderLayout());
-        add(actionPanel, BorderLayout.CENTER);
+        JScrollPane scrollPane = ScrollUtil.buildScrollPane(actionPanel, 10);
+        scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+        add(scrollPane, BorderLayout.CENTER);
         sourceRootDir = new File(Version.SETTINGS_DIR, "quickTags");
         if (!sourceRootDir.exists()) {
             sourceRootDir.mkdirs();
@@ -144,12 +148,6 @@ public class QuickTagPanel extends JPanel {
         if (!sourceDir.exists()) {
             sourceDir.mkdirs();
         }
-        IntegerProperty prop = (IntegerProperty)AppConfig
-                .getInstance()
-                .getPropertiesManager()
-                .getProperty(IceExtension.quickTagPanelWidthProp);
-        int panelWidth = prop == null ? 200 : prop.getValue();
-        actionPanel.setPreferredSize(new Dimension(panelWidth, actionPanel.getPreferredSize().height));
         tagListsByName.clear();
         actionPanel.setAutoRebuildEnabled(false); // Otherwise each add will trigger an ActionPanel rebuild
         try {
@@ -226,12 +224,31 @@ public class QuickTagPanel extends JPanel {
      * the options and configuration set the way we want for our quick tag panels.
      */
     private ActionPanel buildActionPanel() {
-        ActionPanel actionPanel = new ActionPanel();
+        // This is very weird, but calling setPreferredSize() on the ActionPanel itself
+        // prevents the scrollbar from ever showing up, even when the parent container is too
+        // small to show all contents. The only way I've found to make this work is
+        // to override ActionPanel itself and return the preferred size from there.
+        // All of this, by the way, is just so we can set our preferred width. Sigh.
+        ActionPanel actionPanel = new ActionPanel() {
+            @Override
+            public Dimension getPreferredSize() {
+                IntegerProperty prop = (IntegerProperty)AppConfig
+                        .getInstance()
+                        .getPropertiesManager()
+                        .getProperty(IceExtension.quickTagPanelWidthProp);
+                int panelWidth = prop == null ? 200 : prop.getValue();
+                Dimension superPref = super.getPreferredSize();
+                return new Dimension(panelWidth, superPref.height);
+            }
+        };
+
+        // Now we can customize ActionPanel to get it to look the way we want it to.
         actionPanel.setHeaderIconSize(iconSize);
         actionPanel.getToolBarOptions().setIconSize(iconSize);
         actionPanel.setActionComponentType(ActionComponentType.BUTTONS);
         actionPanel.getActionTrayMargins().setAll(0); // no gaps between anything, no margins either
         actionPanel.getToolBarMargins().setAll(0); // This should be redundant in Stretch mode.
+        actionPanel.getActionGroupMargins().setRight(18); // leave room for scrollbar on the right
         actionPanel.setButtonPadding(4); // Give the buttons just a bit more padding than the default 2 pixels.
         actionPanel.addGroupRenamedListener((a, o, n) -> groupRenamed(o, n));
         actionPanel.addGroupRemovedListener((a, g) -> groupRemoved(g));

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
@@ -2,6 +2,7 @@ ext-iv-ice Release Notes
 Author: Steve Corbett
 
 Version 3.0.0 [TODO - release date]
+  #66 - Fix missing scrollbar in quick tag panel
   #61 - Respond to ActionPanel events for quick tag edits
   #59 - Now using ActionPanel for quick tags panel
   #57 - ImageViewer has upgraded to swing-extras 2.8


### PR DESCRIPTION
This issue addresses issue #66 by restoring the vertical scrollbar on the quick tags panel. This was broken during the recent upgrade to the new `ActionPanel` component.