### PR TITLE
Issue #68 workaround actionpanel bug

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -4,5 +4,8 @@
     <inspection_tool class="EnumSwitchStatementWhichMissesCases" enabled="true" level="WARNING" enabled_by_default="true" editorAttributes="WARNING_ATTRIBUTES">
       <option name="ignoreSwitchStatementsWithDefault" value="true" />
     </inspection_tool>
+    <inspection_tool class="ExtractMethodRecommender" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="minLength" value="99999" /> <!-- Stop bothering me with this stupid suggestion -->
+    </inspection_tool>
   </profile>
 </component>

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
@@ -31,6 +31,8 @@ import ca.corbett.imageviewer.extensions.ice.ui.formfield.TagHotkeyProperty;
 import ca.corbett.imageviewer.ui.ImageInstance;
 import ca.corbett.imageviewer.ui.MainWindow;
 import ca.corbett.imageviewer.ui.ThumbPanel;
+import ca.corbett.imageviewer.ui.UIReloadable;
+import ca.corbett.imageviewer.ui.actions.ReloadUIAction;
 import org.apache.commons.io.FilenameUtils;
 
 import javax.swing.JComponent;
@@ -60,7 +62,7 @@ import java.util.logging.Logger;
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  */
-public class IceExtension extends ImageViewerExtension {
+public class IceExtension extends ImageViewerExtension implements UIReloadable {
 
     private static final Logger log = Logger.getLogger(IceExtension.class.getName());
 
@@ -178,11 +180,13 @@ public class IceExtension extends ImageViewerExtension {
     @Override
     public void onActivate() {
         TagIndex.getInstance().load();
+        ReloadUIAction.getInstance().registerReloadable(this);
     }
 
     @Override
     public void onDeactivate() {
         TagIndex.getInstance().save();
+        ReloadUIAction.getInstance().unregisterReloadable(this);
     }
 
     /**
@@ -497,4 +501,10 @@ public class IceExtension extends ImageViewerExtension {
         return label;
     }
 
+    @Override
+    public void reloadUI() {
+        for (QuickTagPanel panel : quickTagPanels) {
+            panel.refreshPreferredWidth(); // user may have changed the preferred quick panel width
+        }
+    }
 }

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
@@ -36,7 +36,6 @@ import org.apache.commons.io.FilenameUtils;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JScrollPane;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Cursor;
@@ -243,11 +242,8 @@ public class IceExtension extends ImageViewerExtension {
         if (getQuickTagPositionFromConfig().contains(position)) {
             QuickTagPanel panel = new QuickTagPanel(position); // create a new one on each request
             quickTagPanels.add(panel);
-            JScrollPane scrollPane = new JScrollPane(panel);
-            scrollPane.getVerticalScrollBar().setUnitIncrement(10);
-            scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
-            scrollPane.setName("ICE"); // short name in case our component gets added to a tab pane
-            return scrollPane;
+            panel.setName("ICE"); // short name in case our component gets added to a tab pane
+            return panel;
         }
 
         return null;

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
@@ -38,7 +38,6 @@ import org.apache.commons.io.FilenameUtils;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JScrollPane;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Cursor;
@@ -188,6 +187,11 @@ public class IceExtension extends ImageViewerExtension implements UIReloadable {
     public void onDeactivate() {
         TagIndex.getInstance().save();
         ReloadUIAction.getInstance().unregisterReloadable(this);
+        for (QuickTagPanel panel : quickTagPanels) {
+            panel.dispose();
+        }
+        quickTagPanels.clear();
+        tagPreviewPanels.clear();
     }
 
     /**

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
@@ -505,6 +505,7 @@ public class IceExtension extends ImageViewerExtension implements UIReloadable {
     public void reloadUI() {
         for (QuickTagPanel panel : quickTagPanels) {
             panel.refreshPreferredWidth(); // user may have changed the preferred quick panel width
+            panel.applyLafWorkaround(); // user may have changed color scheme
         }
     }
 }

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
@@ -88,6 +88,8 @@ public class QuickTagPanel extends JPanel {
     // Size for all icons in our ActionPanel:
     private static final int iconSize = 18;
 
+    private int preferredPanelWidth = 200; // customized via AppConfig
+
     private final ImageViewerExtension.ExtraPanelPosition position;
     private final ActionPanel actionPanel;
     private final File sourceRootDir;
@@ -118,6 +120,7 @@ public class QuickTagPanel extends JPanel {
         this.tagListsByName = new HashMap<>();
         this.actionPanel = buildActionPanel();
 
+        refreshPreferredWidth();
         setLayout(new BorderLayout());
         JScrollPane scrollPane = ScrollUtil.buildScrollPane(actionPanel, 10);
         scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
@@ -128,6 +131,18 @@ public class QuickTagPanel extends JPanel {
         }
 
         reset(); // Force a load of our contents
+    }
+
+    /**
+     * Looks up the currently-configured preferred width for quick tag panels
+     * from application settings and updates the instance variable.
+     */
+    public void refreshPreferredWidth() {
+        IntegerProperty prop = (IntegerProperty)AppConfig
+                .getInstance()
+                .getPropertiesManager()
+                .getProperty(IceExtension.quickTagPanelWidthProp);
+        preferredPanelWidth = prop == null ? 200 : prop.getValue();
     }
 
     /**
@@ -232,13 +247,8 @@ public class QuickTagPanel extends JPanel {
         ActionPanel actionPanel = new ActionPanel() {
             @Override
             public Dimension getPreferredSize() {
-                IntegerProperty prop = (IntegerProperty)AppConfig
-                        .getInstance()
-                        .getPropertiesManager()
-                        .getProperty(IceExtension.quickTagPanelWidthProp);
-                int panelWidth = prop == null ? 200 : prop.getValue();
                 Dimension superPref = super.getPreferredSize();
-                return new Dimension(panelWidth, superPref.height);
+                return new Dimension(preferredPanelWidth, superPref.height);
             }
         };
 

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
@@ -1,6 +1,7 @@
 package ca.corbett.imageviewer.extensions.ice.ui;
 
 import ca.corbett.extras.EnhancedAction;
+import ca.corbett.extras.LookAndFeelManager;
 import ca.corbett.extras.ScrollUtil;
 import ca.corbett.extras.TextInputDialog;
 import ca.corbett.extras.actionpanel.ActionComponentType;
@@ -31,7 +32,11 @@ import javax.swing.ImageIcon;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.UIManager;
+import javax.swing.event.ChangeListener;
+import javax.swing.plaf.ColorUIResource;
 import java.awt.BorderLayout;
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.io.File;
@@ -90,6 +95,8 @@ public class QuickTagPanel extends JPanel {
 
     private int preferredPanelWidth = 200; // customized via AppConfig
 
+    private ColorTheme appliedTheme; // null = no theme applied, use system defaults
+    private final ChangeListener lafListener;
     private final ImageViewerExtension.ExtraPanelPosition position;
     private final ActionPanel actionPanel;
     private final File sourceRootDir;
@@ -131,6 +138,13 @@ public class QuickTagPanel extends JPanel {
         }
 
         reset(); // Force a load of our contents
+
+        // Set up a Look and Feel change listener so we can apply our workaround:
+        lafListener = e -> applyLafWorkaround();
+        LookAndFeelManager.addChangeListener(lafListener);
+
+        // And force the workaround here for immediate effect:
+        applyLafWorkaround();
     }
 
     /**
@@ -279,6 +293,7 @@ public class QuickTagPanel extends JPanel {
         // (otherwise, we'll let the Look and Feel decide all the colors)
         ColorTheme colorTheme = AppConfig.getInstance().getActionPanelTheme();
         if (colorTheme != null) {
+            appliedTheme = colorTheme;
             actionPanel.getColorOptions().setFromTheme(colorTheme);
 
             // Tweak it just a little - I want the action tray background to be the same as
@@ -288,10 +303,37 @@ public class QuickTagPanel extends JPanel {
             options.setToolBarButtonBackground(options.getActionButtonBackground());
         }
         else {
+            appliedTheme = null;
             actionPanel.getColorOptions().useSystemDefaults();
         }
 
         return actionPanel;
+    }
+
+    /**
+     * Works around an unfortunate bug in swing-extras regarding button colors in certain Look and Feels.
+     * This bug was not fixed before swing-extras 2.8 was released :(
+     */
+    public void applyLafWorkaround() {
+        // Work around an unfortunate bug in the swing-extras library
+        // where button borders are set to a very unpleasant default color:
+        if (appliedTheme != null) {
+            Color borderColor = switch (appliedTheme) {
+                case DEFAULT, MATRIX, DARK, ICE -> Color.DARK_GRAY;
+                case LIGHT, GOT_THE_BLUES, SHADES_OF_GRAY -> Color.GRAY;
+                case HOT_DOG_STAND -> Color.YELLOW; // because hot dog stands are ugly
+            };
+            UIManager.put("Button.default.startBorderColor", new ColorUIResource(borderColor));
+            reset(); // seems like overkill but a simple redraw won't hack it here.
+
+            // This is what I want to do instead of reset(),
+            // but it won't work because of the way ActionPanel builds its buttons:
+            //SwingUtilities.updateComponentTreeUI(actionPanel);
+
+            invalidate();
+            validate();
+            repaint();
+        }
     }
 
     /**

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
@@ -1,7 +1,6 @@
 package ca.corbett.imageviewer.extensions.ice.ui;
 
 import ca.corbett.extras.EnhancedAction;
-import ca.corbett.extras.ScrollUtil;
 import ca.corbett.extras.LookAndFeelManager;
 import ca.corbett.extras.ScrollUtil;
 import ca.corbett.extras.TextInputDialog;

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
@@ -353,7 +353,7 @@ public class QuickTagPanel extends JPanel {
         //SwingUtilities.updateComponentTreeUI(actionPanel);
 
         invalidate();
-        validate();
+        revalidate();
         repaint();
     }
 

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
@@ -1,6 +1,7 @@
 package ca.corbett.imageviewer.extensions.ice.ui;
 
 import ca.corbett.extras.EnhancedAction;
+import ca.corbett.extras.ScrollUtil;
 import ca.corbett.extras.TextInputDialog;
 import ca.corbett.extras.actionpanel.ActionComponentType;
 import ca.corbett.extras.actionpanel.ActionPanel;
@@ -29,6 +30,7 @@ import org.apache.commons.io.FilenameUtils;
 import javax.swing.ImageIcon;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.event.ActionEvent;
@@ -117,7 +119,9 @@ public class QuickTagPanel extends JPanel {
         this.actionPanel = buildActionPanel();
 
         setLayout(new BorderLayout());
-        add(actionPanel, BorderLayout.CENTER);
+        JScrollPane scrollPane = ScrollUtil.buildScrollPane(actionPanel, 10);
+        scrollPane.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_NEVER);
+        add(scrollPane, BorderLayout.CENTER);
         sourceRootDir = new File(Version.SETTINGS_DIR, "quickTags");
         if (!sourceRootDir.exists()) {
             sourceRootDir.mkdirs();
@@ -144,12 +148,6 @@ public class QuickTagPanel extends JPanel {
         if (!sourceDir.exists()) {
             sourceDir.mkdirs();
         }
-        IntegerProperty prop = (IntegerProperty)AppConfig
-                .getInstance()
-                .getPropertiesManager()
-                .getProperty(IceExtension.quickTagPanelWidthProp);
-        int panelWidth = prop == null ? 200 : prop.getValue();
-        actionPanel.setPreferredSize(new Dimension(panelWidth, actionPanel.getPreferredSize().height));
         tagListsByName.clear();
         actionPanel.setAutoRebuildEnabled(false); // Otherwise each add will trigger an ActionPanel rebuild
         try {
@@ -226,12 +224,31 @@ public class QuickTagPanel extends JPanel {
      * the options and configuration set the way we want for our quick tag panels.
      */
     private ActionPanel buildActionPanel() {
-        ActionPanel actionPanel = new ActionPanel();
+        // This is very weird, but calling setPreferredSize() on the ActionPanel itself
+        // prevents the scrollbar from ever showing up, even when the parent container is too
+        // small to show all contents. The only way I've found to make this work is
+        // to override ActionPanel itself and return the preferred size from there.
+        // All of this, by the way, is just so we can set our preferred width. Sigh.
+        ActionPanel actionPanel = new ActionPanel() {
+            @Override
+            public Dimension getPreferredSize() {
+                IntegerProperty prop = (IntegerProperty)AppConfig
+                        .getInstance()
+                        .getPropertiesManager()
+                        .getProperty(IceExtension.quickTagPanelWidthProp);
+                int panelWidth = prop == null ? 200 : prop.getValue();
+                Dimension superPref = super.getPreferredSize();
+                return new Dimension(panelWidth, superPref.height);
+            }
+        };
+
+        // Now we can customize ActionPanel to get it to look the way we want it to.
         actionPanel.setHeaderIconSize(iconSize);
         actionPanel.getToolBarOptions().setIconSize(iconSize);
         actionPanel.setActionComponentType(ActionComponentType.BUTTONS);
         actionPanel.getActionTrayMargins().setAll(0); // no gaps between anything, no margins either
         actionPanel.getToolBarMargins().setAll(0); // This should be redundant in Stretch mode.
+        actionPanel.getActionGroupMargins().setRight(18); // leave room for scrollbar on the right
         actionPanel.setButtonPadding(4); // Give the buttons just a bit more padding than the default 2 pixels.
         actionPanel.addGroupRenamedListener((a, o, n) -> groupRenamed(o, n));
         actionPanel.addGroupRemovedListener((a, g) -> groupRemoved(g));

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/QuickTagPanel.java
@@ -95,7 +95,6 @@ public class QuickTagPanel extends JPanel {
 
     private int preferredPanelWidth = 200; // customized via AppConfig
 
-    private ColorTheme appliedTheme; // null = no theme applied, use system defaults
     private final ChangeListener lafListener;
     private final ImageViewerExtension.ExtraPanelPosition position;
     private final ActionPanel actionPanel;
@@ -145,6 +144,14 @@ public class QuickTagPanel extends JPanel {
 
         // And force the workaround here for immediate effect:
         applyLafWorkaround();
+    }
+
+    /**
+     * Invoke this when the QuickTagPanel instance is no longer needed,
+     * to clean things up.
+     */
+    public void dispose() {
+        LookAndFeelManager.removeChangeListener(lafListener);
     }
 
     /**
@@ -293,7 +300,6 @@ public class QuickTagPanel extends JPanel {
         // (otherwise, we'll let the Look and Feel decide all the colors)
         ColorTheme colorTheme = AppConfig.getInstance().getActionPanelTheme();
         if (colorTheme != null) {
-            appliedTheme = colorTheme;
             actionPanel.getColorOptions().setFromTheme(colorTheme);
 
             // Tweak it just a little - I want the action tray background to be the same as
@@ -303,7 +309,6 @@ public class QuickTagPanel extends JPanel {
             options.setToolBarButtonBackground(options.getActionButtonBackground());
         }
         else {
-            appliedTheme = null;
             actionPanel.getColorOptions().useSystemDefaults();
         }
 
@@ -312,28 +317,44 @@ public class QuickTagPanel extends JPanel {
 
     /**
      * Works around an unfortunate bug in swing-extras regarding button colors in certain Look and Feels.
+     * The bug is that button borders are set to a very unpleasant default color for certain LaFs.
      * This bug was not fixed before swing-extras 2.8 was released :(
      */
     public void applyLafWorkaround() {
-        // Work around an unfortunate bug in the swing-extras library
-        // where button borders are set to a very unpleasant default color:
+        // If a custom ActionPanel theme is in effect, tweak it:
+        Color borderColor;
+        ColorTheme appliedTheme = AppConfig.getInstance().getActionPanelTheme();
         if (appliedTheme != null) {
-            Color borderColor = switch (appliedTheme) {
+            borderColor = switch (appliedTheme) {
                 case DEFAULT, MATRIX, DARK, ICE -> Color.DARK_GRAY;
                 case LIGHT, GOT_THE_BLUES, SHADES_OF_GRAY -> Color.GRAY;
                 case HOT_DOG_STAND -> Color.YELLOW; // because hot dog stands are ugly
             };
-            UIManager.put("Button.default.startBorderColor", new ColorUIResource(borderColor));
-            reset(); // seems like overkill but a simple redraw won't hack it here.
-
-            // This is what I want to do instead of reset(),
-            // but it won't work because of the way ActionPanel builds its buttons:
-            //SwingUtilities.updateComponentTreeUI(actionPanel);
-
-            invalidate();
-            validate();
-            repaint();
         }
+
+        // If we're letting the Look and Feel decide our colors, then we'll
+        // decide based on whether the current LaF is dark or light.
+        // This isn't perfect, but it's better than the default:
+        else {
+            borderColor = LookAndFeelManager.isDark() ? Color.DARK_GRAY : Color.GRAY;
+        }
+
+        // Now overwrite the UIManager property in question:
+        // (This will have effects beyond our own action panel, but it is what it is
+        //  until this bug is properly addressed in swing-extras)
+        UIManager.put("Button.default.startBorderColor", new ColorUIResource(borderColor));
+
+        // Rebuild the action panel's UI without reloading contents from disk:
+        actionPanel.setAutoRebuildEnabled(false);
+        actionPanel.setAutoRebuildEnabled(true); // forces an immediate rebuild
+
+        // This is what I want to do instead of the above,
+        // but it won't work because of the way ActionPanel builds its buttons:
+        //SwingUtilities.updateComponentTreeUI(actionPanel);
+
+        invalidate();
+        validate();
+        repaint();
     }
 
     /**

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
@@ -2,6 +2,7 @@ ext-iv-ice Release Notes
 Author: Steve Corbett
 
 Version 3.0.0 [TODO - release date]
+  #68 - Add workaround for swing-extras ActionPanel bug :(
   #66 - Fix missing scrollbar in quick tag panel
   #61 - Respond to ActionPanel events for quick tag edits
   #59 - Now using ActionPanel for quick tags panel

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
@@ -2,6 +2,7 @@ ext-iv-ice Release Notes
 Author: Steve Corbett
 
 Version 3.0.0 [TODO - release date]
+  #66 - Fix missing scrollbar in quick tag panel
   #61 - Respond to ActionPanel events for quick tag edits
   #59 - Now using ActionPanel for quick tags panel
   #57 - ImageViewer has upgraded to swing-extras 2.8


### PR DESCRIPTION
This PR addresses issue #68 by introducing a workaround for an unfortunate bug in the upstream swing-extras library. Button borders are sometimes being given a hard-coded and very unpleasant default border. We can work around this bug by listening for Look and Feel changes and UI reloads within the application, and applying more sensible button border colors for our ActionPanel.
