### PR TITLE
Issue #76 - update comments regarding UIReload for auto-tag feature

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagAction.java
@@ -62,6 +62,9 @@ public class AutoTagAction extends EnhancedAction {
                                 FilenameUtils.getBaseName(currentImage.getImageFile().getName()) + ".ice");
         TagList originalTags = TagList.fromFile(tagFile); // might be empty; that's okay
 
+        // Create a new AiConnectionManager for this request.
+        // This will query AppConfig for all the latest LLM connection settings,
+        // and validate them before proceeding.
         AiConnectionManager aiManager = new AiConnectionManager(requestTemplate, requestTemplateTagless);
         aiManager.requestAutoTag(imageFile, tagList -> {
             // An "empty" return is one where we got back either a completely empty list,

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiConnectionManager.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiConnectionManager.java
@@ -22,7 +22,6 @@ import java.util.logging.Logger;
  * Some TODO items, in no particular order:
  * </p>
  * <ul>
- *     <li>Wire this up to the UI reload action so if the user changes LLM config, we pick up the new values.</li>
  *     <li>Right now we're using template json from our jar resources and just search and replacing certain keys
  *         to form the request. This works, but is overly simplistic. We should probably use the openai-java
  *         library instead of forming raw REST requests ourselves.</li>
@@ -94,7 +93,8 @@ public class AiConnectionManager {
         this.jsonTemplateTagless = jsonTemplateTagless;
 
         // We'll load this here in the constructor.
-        // Really, we should wire up to the UIReloadAction so we can refresh it when it's modified...
+        // Our assumption is that this class is instantiated on demand, rather than keeping an instance around.
+        // So, we don't need to wire up to the UIReload mechanism to watch for config changes.
         populateConfig();
     }
 


### PR DESCRIPTION
Issue #76 asked for `AiConnectionManager` to be wired up to the UIReload mechanism in the parent application. But, it turns out that we don't keep a single, long-running instance of `AiConnectionManager` in this extension. Instead, a new instance of it is created by the `AutoTagAction` for each new request. LLM configuration is loaded by the `AiConnectionManager` constructor on each new instantiation, so each new instance will always have the latest available configuration. Issue #76 therefore describes a change that we don't actually need.

I've updated the comments to better describe how this works, and to document our assumption that we don't keep a single instance of the connection manager around for longer than one single request.