### PR TITLE
Issue #77 - Auto-tag: improved error handling and reporting

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagAction.java
@@ -5,6 +5,7 @@ import ca.corbett.imageviewer.extensions.ImageViewerExtensionManager;
 import ca.corbett.imageviewer.extensions.ice.TagIndex;
 import ca.corbett.imageviewer.extensions.ice.TagList;
 import ca.corbett.imageviewer.extensions.ice.llm.AiConnectionManager;
+import ca.corbett.imageviewer.extensions.ice.llm.AiErrorBody;
 import ca.corbett.imageviewer.ui.ImageInstance;
 import ca.corbett.imageviewer.ui.MainWindow;
 import org.apache.commons.io.FilenameUtils;
@@ -55,18 +56,40 @@ public class AutoTagAction extends EnhancedAction {
             return;
         }
 
-        // Find the tag file for this image.
-        // It's not an error if this file does not exist...
-        // We'll just end up creating it if/when we get the results from the LLM.
-        File tagFile = new File(currentImage.getImageFile().getParentFile(),
-                                FilenameUtils.getBaseName(currentImage.getImageFile().getName()) + ".ice");
-        TagList originalTags = TagList.fromFile(tagFile); // might be empty; that's okay
-
         // Create a new AiConnectionManager for this request.
         // This will query AppConfig for all the latest LLM connection settings,
         // and validate them before proceeding.
         AiConnectionManager aiManager = new AiConnectionManager(requestTemplate, requestTemplateTagless);
-        aiManager.requestAutoTag(imageFile, tagList -> {
+        CallbackHandler handler = new CallbackHandler(imageFile);
+        aiManager.requestAutoTag(imageFile, handler, handler);
+    }
+
+    /**
+     * Invoked when we get a response back from the LLM, whether it's a success or an error.
+     */
+    private static class CallbackHandler
+            implements AiConnectionManager.CompletionCallback, AiConnectionManager.ErrorCallback {
+        private final File imageFile;
+        private final File tagFile;
+        private final TagList originalTags;
+
+        public CallbackHandler(File imageFile) {
+            this.imageFile = imageFile;
+
+            // Find the tag file for this image.
+            // It's not an error if this file does not exist...
+            // We'll just end up creating it if/when we get the results from the LLM.
+            this.tagFile = new File(imageFile.getParentFile(), FilenameUtils.getBaseName(imageFile.getName()) + ".ice");
+            this.originalTags = TagList.fromFile(tagFile); // might be empty; that's okay
+        }
+
+        /**
+         * This will be called when we get a successful response from the LLM.
+         * The tags parameter will contain the list of tags returned by the LLM, which may be empty.
+         * We will need to merge these tags with the existing tags for the image, and then update the UI accordingly.
+         */
+        @Override
+        public void onComplete(TagList tagList) {
             // An "empty" return is one where we got back either a completely empty list,
             // or a list with just the NO_TAG sentinel value.
             boolean isEmpty = tagList.isEmpty()
@@ -87,6 +110,22 @@ public class AutoTagAction extends EnhancedAction {
             SwingUtilities.invokeLater(() -> {
                 ImageViewerExtensionManager.getInstance().imageSelected(MainWindow.getInstance().getSelectedImage());
             });
-        });
+        }
+
+        /**
+         * This will be called if there was an error sending the request or parsing the response.
+         * The error parameter will contain details about what went wrong, which we can display to the user.
+         */
+        @Override
+        public void onError(AiErrorBody error) {
+            // The request thread already logged the error, so we can just show a simple error message to the user.
+            String msg = "Failed to auto-tag image: "
+                    + "\n\nMessage:" + error.getMessage()
+                    + "\nCode: " + error.getCode()
+                    + "\nType: " + error.getType();
+            SwingUtilities.invokeLater(() -> {
+                MainWindow.getInstance().showMessageDialog(NAME, msg);
+            });
+        }
     }
 }

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagAction.java
@@ -118,10 +118,12 @@ public class AutoTagAction extends EnhancedAction {
          */
         @Override
         public void onError(AiErrorBody error) {
+            String errorCode = error.getCode() == AiErrorBody.INTERNAL_ERROR ? "(Internal error)" : error.getCode() + "";
+
             // The request thread already logged the error, so we can just show a simple error message to the user.
             String msg = "Failed to auto-tag image: "
                     + "\n\nMessage:" + error.getMessage()
-                    + "\nCode: " + error.getCode()
+                    + "\nCode: " + errorCode
                     + "\nType: " + error.getType();
             SwingUtilities.invokeLater(() -> {
                 MainWindow.getInstance().showMessageDialog(NAME, msg);

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiCompletionsBody.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiCompletionsBody.java
@@ -1,6 +1,7 @@
 package ca.corbett.imageviewer.extensions.ice.llm;
 
 import ca.corbett.imageviewer.extensions.ice.TagList;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -36,6 +37,7 @@ import java.util.List;
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class AiCompletionsBody {
 
     @JsonProperty("choices")
@@ -76,6 +78,7 @@ public class AiCompletionsBody {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
     public static class ChoiceNode {
         @JsonProperty("finish_reason")
         private String finishReason;
@@ -85,6 +88,7 @@ public class AiCompletionsBody {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
     public static class MessageNode {
         @JsonProperty("role")
         private String role; // always "assistant" in our case

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiConnectionManager.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiConnectionManager.java
@@ -106,11 +106,17 @@ public class AiConnectionManager {
     /**
      * Starts an async request to auto-tag the given image with our configured LLM.
      * Your onComplete callback will receive the resulting TagList when the request is complete.
-     * If the image could not be auto-tagged for any reason, the TagList will have a single
-     * entry with the special NO_TAGS tag. This also applies if the LLM feature is disabled.
-     * The callback may be invoked from the worker thread! Take care to check if you are on
+     * The resulting tag list may contain only the special NO_TAGS tag if the LLM was unable to
+     * determine any tags for the image, or if the feature is disabled.
+     * <p>
+     * If an error occurs, the onError callback will be invoked with an AiErrorBody describing
+     * what went wrong.
+     * </p>
+     * <p>
+     * Both callbacks may be invoked from the worker thread! Take care to check if you are on
      * the UI thread when your callback is invoked, and if not, use SwingUtilities.invokeLater()
      * to switch to the UI thread before making any UI updates.
+     * </p>
      *
      * @param imageFile  The image file to auto-tag. Must not be null. Currently only PNG and JPEG formats are supported.
      * @param onComplete The CompletionCallback to invoke when done. Must not be null.

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiConnectionManager.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiConnectionManager.java
@@ -51,6 +51,11 @@ public class AiConnectionManager {
         void onComplete(TagList tagList);
     }
 
+    @FunctionalInterface
+    public interface ErrorCallback {
+        void onError(AiErrorBody error);
+    }
+
     private static final Logger log = Logger.getLogger(AiConnectionManager.class.getName());
 
     private final String jsonTemplate;
@@ -109,8 +114,9 @@ public class AiConnectionManager {
      *
      * @param imageFile  The image file to auto-tag. Must not be null. Currently only PNG and JPEG formats are supported.
      * @param onComplete The CompletionCallback to invoke when done. Must not be null.
+     * @param onError   The ErrorCallback to invoke if something goes wrong. Must not be null.
      */
-    public void requestAutoTag(File imageFile, CompletionCallback onComplete) {
+    public void requestAutoTag(File imageFile, CompletionCallback onComplete, ErrorCallback onError) {
         if (imageFile == null) {
             throw new IllegalArgumentException("Image file must not be null");
         }
@@ -122,8 +128,8 @@ public class AiConnectionManager {
             throw new IllegalArgumentException("Unsupported image format for file: " + imageFile.getAbsolutePath()
                                                        + " - only PNG and JPEG are supported");
         }
-        if (onComplete == null) {
-            throw new IllegalArgumentException("Completion callback must not be null");
+        if (onComplete == null || onError == null) {
+            throw new IllegalArgumentException("Completion and error callbacks must not be null");
         }
         if (!featureEnabled) {
             log.warning("LLM auto-tagging requested but feature is disabled - returning NO_TAGS");
@@ -135,7 +141,7 @@ public class AiConnectionManager {
 
         // Fire off a worker thread to do this for us:
         MultiProgressDialog dialog = new MultiProgressDialog(MainWindow.getInstance(), "Auto-tagging image...");
-        AiRequestThread requestThread = new AiRequestThread(imageFile, this, onComplete);
+        AiRequestThread requestThread = new AiRequestThread(imageFile, this, onComplete, onError);
         dialog.runWorker(requestThread, true);
     }
 

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiErrorBody.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiErrorBody.java
@@ -1,5 +1,6 @@
 package ca.corbett.imageviewer.extensions.ice.llm;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
@@ -22,15 +23,45 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class AiErrorBody {
     private ErrorNode error;
+
+    /**
+     * "Internal" here does not refer to 500 Internal Server Error, but rather
+     * to any error that occurs within this extension, including when we
+     * are unable to parse the error response body from the LLM.
+     */
+    public static final int INTERNAL_ERROR = -1;
+
+    /**
+     * Static convenience method to create an AiErrorBody from the given code, error type, and message.
+     * The errorCode in that case will be INTERNAL_ERROR.
+     */
+    public static AiErrorBody of(String errorType, String message) {
+        return of(INTERNAL_ERROR, errorType, message);
+    }
+
+    /**
+     * If you actually have an error code, you can use this method to create an AiErrorBody with that code,
+     * along with the error type and message.
+     */
+    public static AiErrorBody of(int errorCode, String errorType, String message) {
+        AiErrorBody body = new AiErrorBody();
+        ErrorNode errorNode = new ErrorNode();
+        errorNode.code = errorCode;
+        errorNode.type = errorType;
+        errorNode.message = message;
+        body.error = errorNode;
+        return body;
+    }
 
     /**
      * Returns the numeric error code, if we were able to parse it, otherwise returns -1.
      */
     public int getCode() {
         if (error == null) {
-            return -1;
+            return INTERNAL_ERROR;
         }
         return error.code;
     }
@@ -56,6 +87,7 @@ public class AiErrorBody {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
     public static class ErrorNode {
         private int code;
         private String message;

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiRequestThread.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiRequestThread.java
@@ -12,6 +12,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.util.Base64;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -34,10 +35,15 @@ public class AiRequestThread extends SimpleProgressWorker {
     private final File imageFile;
     private final AiConnectionManager manager;
     private final AiConnectionManager.CompletionCallback onComplete;
+    private final AiConnectionManager.ErrorCallback onError;
 
-    public AiRequestThread(File imageFile, AiConnectionManager manager, AiConnectionManager.CompletionCallback onComplete) {
+    public AiRequestThread(File imageFile,
+                           AiConnectionManager manager,
+                           AiConnectionManager.CompletionCallback onComplete,
+                           AiConnectionManager.ErrorCallback onError) {
         this.manager = manager;
         this.onComplete = onComplete;
+        this.onError = onError;
         this.imageFile = imageFile;
     }
 
@@ -64,7 +70,8 @@ public class AiRequestThread extends SimpleProgressWorker {
             }
             catch (Exception e) {
                 log.severe("Failed to read and encode image file: " + e.getMessage());
-                onComplete.onComplete(noTags());
+                onError.onError(AiErrorBody.of(e.getClass().getName(),
+                                               "Failed to read and encode image file: " + e.getMessage()));
                 return;
             }
 
@@ -94,14 +101,17 @@ public class AiRequestThread extends SimpleProgressWorker {
                         log.severe("LLM request failed with status code " + response.statusCode() + ": "
                                            + errorBody.getMessage() + " (code " + errorBody.getCode() + ", type "
                                            + errorBody.getType() + ")");
+                        onError.onError(errorBody);
                     }
                     catch (Exception e) {
                         // We were unable to parse it, so best we can do is show the generic error code:
                         // (we *could* log the response body, but it might be huge, and it might leak
                         //  server info into the log, so we'll just let it go)
                         log.severe("LLM request failed with status code " + response.statusCode());
+                        onError.onError(AiErrorBody.of(response.statusCode(),
+                                                       "HTTP error",
+                                                       "LLM request failed with status code " + response.statusCode()));
                     }
-                    onComplete.onComplete(noTags());
                     return;
                 }
 
@@ -119,8 +129,9 @@ public class AiRequestThread extends SimpleProgressWorker {
                 }
             }
             catch (Exception e) {
-                log.severe("Failed to send LLM request or parse response: " + e.getMessage());
-                onComplete.onComplete(noTags());
+                log.log(Level.SEVERE, "Failed to send LLM request or parse response: " + e.getMessage(), e);
+                onError.onError(AiErrorBody.of(e.getClass().getName(),
+                                               "Failed to send LLM request or parse response: " + e.getMessage()));
             }
         }
         finally {

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiResponseBody.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiResponseBody.java
@@ -1,5 +1,6 @@
 package ca.corbett.imageviewer.extensions.ice.llm;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
@@ -19,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class AiResponseBody {
     private String status;
     private OutputNode[] output;
@@ -67,12 +69,14 @@ public class AiResponseBody {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
     public static class OutputNode {
         private String type;
         private ContentNode[] content;
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
     public static class ContentNode {
         private String type;
         private String text;

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
@@ -2,6 +2,7 @@ ext-iv-ice Release Notes
 Author: Steve Corbett
 
 Version 3.3.0 [TODO: release date]
+  #77 - Auto-tag: improved error handling and reporting
   #73 - add auto-tag support via LLM (highly experimental!)
 
 Version 3.2.0 [2026-04-19]


### PR DESCRIPTION
This PR addresses issue #77 by adding improved error handling and reporting for the auto-tag feature. If the LLM server reports an error, we'll make a best-effort attempt to parse the error code, type, and message, log them, and display them to the user in a message dialog. 

If I deliberately submit unparseable image data, I confirm that I now see a user-friendly dialog explaining what went wrong. Had to adjust the json model classes a bit to enable this to work properly.
