### PR TITLE
Issue #79 - Auto-tag: show tag preview/edit dialog

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagAction.java
@@ -97,8 +97,12 @@ public class AutoTagAction extends EnhancedAction {
             boolean isEmpty = tagList.isEmpty()
                     || (tagList.size() == 1 && tagList.getTags().get(0).equals(AiConnectionManager.NO_TAGS));
 
-            // Wonky case: if originalTags isn't empty, and we get back an "empty" list, then do nothing.
-            if (!originalTags.isEmpty() && isEmpty) {
+            // If we get back such a list, let the user know:
+            if (isEmpty) {
+                SwingUtilities.invokeLater(() -> {
+                    MainWindow.getInstance().showMessageDialog(NAME,
+                                                               "The LLM had no tag suggestions for this image.");
+                });
                 return;
             }
 

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagAction.java
@@ -1,11 +1,13 @@
 package ca.corbett.imageviewer.extensions.ice.actions;
 
 import ca.corbett.extras.EnhancedAction;
+import ca.corbett.extras.TextInputDialog;
 import ca.corbett.imageviewer.extensions.ImageViewerExtensionManager;
 import ca.corbett.imageviewer.extensions.ice.TagIndex;
 import ca.corbett.imageviewer.extensions.ice.TagList;
 import ca.corbett.imageviewer.extensions.ice.llm.AiConnectionManager;
 import ca.corbett.imageviewer.extensions.ice.llm.AiErrorBody;
+import ca.corbett.imageviewer.extensions.ice.ui.formfield.TagListValidator;
 import ca.corbett.imageviewer.ui.ImageInstance;
 import ca.corbett.imageviewer.ui.MainWindow;
 import org.apache.commons.io.FilenameUtils;
@@ -100,16 +102,8 @@ public class AutoTagAction extends EnhancedAction {
                 return;
             }
 
-            // Otherwise, add all the new tags to the original tag list:
-            originalTags.addAll(tagList); // duplicates are pruned automatically, not a big deal.
-            originalTags.save(); // commit changes to disk
-            TagIndex.getInstance().addOrUpdateEntry(imageFile, tagFile); // tell the TagIndex of this change
-
-            // Select the already-selected image to force a UI update of the displayed tags:
-            // (we may or may not be on the UI thread in this callback, so let's be safe with our UI update)
-            SwingUtilities.invokeLater(() -> {
-                ImageViewerExtensionManager.getInstance().imageSelected(MainWindow.getInstance().getSelectedImage());
-            });
+            // Show the suggested tags to the user and allow review/edit:
+            SwingUtilities.invokeLater(() -> reviewAndAccept(tagList));
         }
 
         /**
@@ -128,6 +122,36 @@ public class AutoTagAction extends EnhancedAction {
             SwingUtilities.invokeLater(() -> {
                 MainWindow.getInstance().showMessageDialog(NAME, msg);
             });
+        }
+
+        /**
+         * Make sure this gets invoked on the UI thread!
+         * This method shows dialogs and performs UI updates.
+         */
+        private void reviewAndAccept(TagList suggestedTags) {
+            TextInputDialog dialog = new TextInputDialog(MainWindow.getInstance(),
+                                                         "Suggested tags", TextInputDialog.InputType.MultiLine);
+            dialog.setAllowBlank(false);
+            dialog.setConfirmLabel("Add tags");
+            dialog.addValidator(new TagListValidator());
+            dialog.setPrompt("Suggested tags:");
+            dialog.setInitialText(suggestedTags.toString());
+            dialog.setVisible(true);
+
+            String modifiedTagStr = dialog.getResult();
+            if (modifiedTagStr == null) {
+                // User canceled, so do nothing.
+                return;
+            }
+
+            // Otherwise, add all the new tags to the original tag list:
+            TagList modifiedTags = TagList.of(modifiedTagStr);
+            originalTags.addAll(modifiedTags); // duplicates are pruned automatically, not a big deal.
+            originalTags.save(); // commit changes to disk
+            TagIndex.getInstance().addOrUpdateEntry(imageFile, tagFile); // tell the TagIndex of this change
+
+            // Select the already-selected image to force a UI update of the displayed tags:
+            ImageViewerExtensionManager.getInstance().imageSelected(MainWindow.getInstance().getSelectedImage());
         }
     }
 }

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiConnectionManager.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiConnectionManager.java
@@ -25,17 +25,10 @@ import java.util.logging.Logger;
  *     <li>Right now we're using template json from our jar resources and just search and replacing certain keys
  *         to form the request. This works, but is overly simplistic. We should probably use the openai-java
  *         library instead of forming raw REST requests ourselves.</li>
- *     <li>Currently we lean heavily on logging to report errors. We should have an ErrorCallback
- *         so that we can properly display an error dialog to the user if something goes wrong.
- *         Basically, if the user isn't watching the log output, they may have no idea what happened.</li>
  *     <li>Currently, you can only request an auto-tag for the selected image. It would be great to
  *         have a "batch mode", where it goes through all images in a directory, with optional recursion.</li>
  *     <li>Currently, the auto-tag can only be triggered from a configurable keyboard shortcut. It would be
  *         nice to have a menu item or toolbar button or right-click popup option or something.</li>
- *     <li>Currently, we blindly append all LLM-suggested tags to the image's tag list. Would be a much
- *         nicer UX to pop up a dialog showing the suggested tags, and allow user editing before
- *         confirmation. This is especially nice if the LLM was not given a constrained tag list, because
- *         the suggested tags may be wrong (or inconsistent).</li>
  * </ul>
  * <p>
  *     The above TODOs will be handled in future tickets, if the initial proof-of-concept works out.

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/formfield/TagListValidator.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/formfield/TagListValidator.java
@@ -1,0 +1,57 @@
+package ca.corbett.imageviewer.extensions.ice.ui.formfield;
+
+import ca.corbett.forms.fields.FormField;
+import ca.corbett.forms.fields.LongTextField;
+import ca.corbett.forms.fields.ShortTextField;
+import ca.corbett.forms.validators.FieldValidator;
+import ca.corbett.forms.validators.ValidationResult;
+import ca.corbett.imageviewer.extensions.ice.TagList;
+
+import java.util.logging.Logger;
+
+/**
+ * Attach this validator to any ShortTextField or LongTextField to ensure that the given
+ * input is a valid, non-empty tag list according to the rules of our TagList class.
+ * See TagList.isValidNonEmptyTagString().
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class TagListValidator implements FieldValidator<FormField> {
+    private static final Logger log = Logger.getLogger(TagListValidator.class.getName());
+
+    @Override
+    public ValidationResult validate(FormField fieldToValidate) {
+        if (fieldToValidate == null) {
+            log.warning("Null field passed to TagListValidator; this should not happen. Ignoring.");
+            return ValidationResult.valid(); // just ignore nonsense input, shouldn't happen anyway
+        }
+
+        String text = null;
+        if (fieldToValidate instanceof ShortTextField textField) {
+            text = textField.getText();
+        }
+        else if (fieldToValidate instanceof LongTextField textField) {
+            text = textField.getText();
+        }
+
+        if (text == null) {
+            log.warning("Unexpected field type passed to TagListValidator: "
+                                + fieldToValidate.getClass().getName()
+                                + "; expected LongTextField or ShortTextField.");
+            return ValidationResult.valid(); // unexpected field type; just pass it.
+        }
+
+        // We have to handle this separately because isValidNonEmptyTagString() will simply
+        // return false if the input is blank OR invalid, so we won't be able to tell what went wrong.
+        if (text.isBlank()) {
+            return ValidationResult.invalid("Tag list cannot be blank.");
+        }
+
+        // Now we can rely on TagList to check for invalid characters and formatting:
+        if (!TagList.isValidNonEmptyTagString(text)) {
+            return ValidationResult.invalid(TagList.TAG_FORMAT_ERROR);
+        }
+
+        return ValidationResult.valid();
+    }
+}

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
@@ -2,6 +2,7 @@ ext-iv-ice Release Notes
 Author: Steve Corbett
 
 Version 3.3.0 [TODO: release date]
+  #79 - Auto-tag: add suggested tag preview dialog
   #77 - Auto-tag: improved error handling and reporting
   #73 - add auto-tag support via LLM (highly experimental!)
 


### PR DESCRIPTION
This PR addresses issue #79 by showing an editable preview of the image tags that were suggested by the LLM, before applying them. The user has the opportunity to add, remove, or modify tags before applying them, or the user can cancel the preview dialog to prevent any of the suggested tags from being applied.
