### PR TITLE
Issue #78 - Auto-tag: add batch option

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
@@ -18,6 +18,7 @@ import ca.corbett.imageviewer.AppConfig;
 import ca.corbett.imageviewer.ImageOperation;
 import ca.corbett.imageviewer.extensions.ImageViewerExtension;
 import ca.corbett.imageviewer.extensions.ice.actions.AutoTagAction;
+import ca.corbett.imageviewer.extensions.ice.actions.AutoTagBatchAction;
 import ca.corbett.imageviewer.extensions.ice.actions.QuickTagToggleLeftAction;
 import ca.corbett.imageviewer.extensions.ice.actions.QuickTagToggleLeftRightAction;
 import ca.corbett.imageviewer.extensions.ice.actions.QuickTagToggleRightAction;
@@ -105,12 +106,13 @@ public class IceExtension extends ImageViewerExtension implements UIReloadable {
     public static final String quickTagShortcutRightProp = QUICK_TAG_TOGGLE + "quickTagPanelRight";
     public static final String quickTagShortcutLeftRightProp = QUICK_TAG_TOGGLE + "quickTagPanelLeftRight";
 
-    public static final String llmIntroLabelProp = "ICE.LLM connection.introLabel";
-    public static final String llmApiKeyProp = "ICE.LLM connection.apiKey";
-    public static final String llmModelProp = "ICE.LLM connection.model";
-    public static final String llmUrlProp = "ICE.LLM connection.url";
-    public static final String llmTagsProp = "ICE.LLM connection.tags";
-    public static final String autoTagKeyProp = "ICE.LLM connection.autoTagHotKey"; // doesn't belong here...
+    public static final String llmIntroLabelProp = "ICE.Auto-tag.introLabel";
+    public static final String llmApiKeyProp = "ICE.Auto-tag.apiKey";
+    public static final String llmModelProp = "ICE.Auto-tag.model";
+    public static final String llmUrlProp = "ICE.Auto-tag.url";
+    public static final String llmTagsProp = "ICE.Auto-tag.tags";
+    public static final String autoTagKeyProp = "ICE.Auto-tag.autoTagHotKey";
+    public static final String autoTagBatchKeyProp = "ICE.Auto-tag.autoTagBatchHotKey";
 
     private final List<TagPreviewPanel> tagPreviewPanels = new ArrayList<>();
     private final List<QuickTagPanel> quickTagPanels = new ArrayList<>();
@@ -214,13 +216,21 @@ public class IceExtension extends ImageViewerExtension implements UIReloadable {
                          .setHelpText("<html>Comma-separated list of tags.<br>" +
                                               "If specified, tag generation will be restricted to just these.<br>" +
                                               "Leave blank to let the LLM decide (results unpredictable!)</html>"));
-        list.add(new KeyStrokeProperty(autoTagKeyProp, "Auto-tag hotkey:",
+        list.add(new KeyStrokeProperty(autoTagKeyProp, "Auto-tag selected:",
                                        KeyStrokeManager.parseKeyStroke("F9"), // Why F9? I dunno.
                                        AutoTagAction.getInstance(imageAnalysisTemplate, imageAnalysisTemplateNoTags))
                          .setAllowBlank(false) // there's no other way to trigger this action currently
                          .setReservedKeyStrokes(AppConfig.RESERVED_KEYSTROKES)
                          .setHelpText(
                                  "<html>Requests auto-tagging of the selected image from the configured LLM.</html>"));
+        list.add(new KeyStrokeProperty(autoTagBatchKeyProp, "Auto-tag batch:",
+                                       KeyStrokeManager.parseKeyStroke("Ctrl+F9"), // Why Ctrl+F9? I dunno.
+                                       AutoTagBatchAction.getInstance(imageAnalysisTemplate,
+                                                                      imageAnalysisTemplateNoTags))
+                         .setAllowBlank(false) // there's no other way to trigger this action currently
+                         .setReservedKeyStrokes(AppConfig.RESERVED_KEYSTROKES)
+                         .setHelpText("<html>Shows a dialog that allows auto-tagging of all jpeg and/or png images" +
+                                              "<br>in the current directory, with optional recursion.</html>"));
 
         // Add a few configurable hotkeys for commonly-used tags:
         for (int i = 1; i <= 8; i++) {
@@ -354,6 +364,14 @@ public class IceExtension extends ImageViewerExtension implements UIReloadable {
             if (browseMode == MainWindow.BrowseMode.FILE_SYSTEM) {
                 actions.add(new TagDirStatsAction());
                 actions.add(new RandomImageSetAction());
+            }
+
+            // Auto-tag menu items:
+            actions.add(AutoTagAction.getInstance(imageAnalysisTemplate, imageAnalysisTemplateNoTags));
+            if (browseMode == MainWindow.BrowseMode.FILE_SYSTEM) {
+                // Batch mode only available if we're browsing directories:
+                // (though it would be a neat feature to batch-tag all images in an image set... maybe later)
+                actions.add(AutoTagBatchAction.getInstance(imageAnalysisTemplate, imageAnalysisTemplateNoTags));
             }
         }
 

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
@@ -219,7 +219,7 @@ public class IceExtension extends ImageViewerExtension implements UIReloadable {
         list.add(new KeyStrokeProperty(autoTagKeyProp, "Auto-tag selected:",
                                        KeyStrokeManager.parseKeyStroke("F9"), // Why F9? I dunno.
                                        AutoTagAction.getInstance(imageAnalysisTemplate, imageAnalysisTemplateNoTags))
-                         .setAllowBlank(false) // there's no other way to trigger this action currently
+                         .setAllowBlank(true)
                          .setReservedKeyStrokes(AppConfig.RESERVED_KEYSTROKES)
                          .setHelpText(
                                  "<html>Requests auto-tagging of the selected image from the configured LLM.</html>"));
@@ -227,7 +227,7 @@ public class IceExtension extends ImageViewerExtension implements UIReloadable {
                                        KeyStrokeManager.parseKeyStroke("Ctrl+F9"), // Why Ctrl+F9? I dunno.
                                        AutoTagBatchAction.getInstance(imageAnalysisTemplate,
                                                                       imageAnalysisTemplateNoTags))
-                         .setAllowBlank(false) // there's no other way to trigger this action currently
+                         .setAllowBlank(true)
                          .setReservedKeyStrokes(AppConfig.RESERVED_KEYSTROKES)
                          .setHelpText("<html>Shows a dialog that allows auto-tagging of all jpeg and/or png images" +
                                               "<br>in the current directory, with optional recursion.</html>"));

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagAction.java
@@ -62,6 +62,16 @@ public class AutoTagAction extends EnhancedAction {
         // This will query AppConfig for all the latest LLM connection settings,
         // and validate them before proceeding.
         AiConnectionManager aiManager = new AiConnectionManager(requestTemplate, requestTemplateTagless);
+
+        // Make sure our config is good before proceeding:
+        if (!aiManager.isFeatureEnabled()) {
+            MainWindow.getInstance().showMessageDialog(NAME,
+                                                       "Auto-tag is not available because the LLM connection is not properly configured." +
+                                                               "\nVisit the Auto-tag settings page in application properties to set it up.");
+            return;
+        }
+
+        // Now we can proceed with the request, and we will handle the response in the callback handler:
         CallbackHandler handler = new CallbackHandler(imageFile);
         aiManager.requestAutoTag(imageFile, handler, handler);
     }

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagAction.java
@@ -23,7 +23,7 @@ import java.io.File;
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  */
 public class AutoTagAction extends EnhancedAction {
-    private static final String NAME = "Auto-tag image";
+    private static final String NAME = "Auto-tag selected image";
 
     private static AutoTagAction instance;
 

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagBatchAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagBatchAction.java
@@ -1,0 +1,66 @@
+package ca.corbett.imageviewer.extensions.ice.actions;
+
+import ca.corbett.extras.EnhancedAction;
+import ca.corbett.imageviewer.extensions.ice.llm.AiConnectionManager;
+import ca.corbett.imageviewer.extensions.ice.ui.dialogs.AutoTagBatchDialog;
+import ca.corbett.imageviewer.ui.MainWindow;
+
+import java.awt.event.ActionEvent;
+import java.io.File;
+
+/**
+ * Shows a dialog that allows auto-tagging of all jpeg and/or png images in the selected
+ * directory, with optional recursion. This feature is experimental and subject to change!
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class AutoTagBatchAction extends EnhancedAction {
+    private static final String NAME = "Auto-tag images...";
+
+    private static AutoTagBatchAction instance;
+
+    private final String requestTemplate;
+    private final String requestTemplateTagless;
+
+    private AutoTagBatchAction(String requestTemplate, String requestTemplateTagless) {
+        super(NAME);
+        this.requestTemplate = requestTemplate;
+        this.requestTemplateTagless = requestTemplateTagless;
+    }
+
+    public static AutoTagBatchAction getInstance(String requestTemplate, String requestTemplateTagless) {
+        if (instance == null) {
+            instance = new AutoTagBatchAction(requestTemplate, requestTemplateTagless);
+        }
+        return instance;
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        File dir = MainWindow.getInstance().getCurrentDirectory();
+        if (dir == null) {
+            MainWindow.getInstance().showMessageDialog(NAME, "Nothing selected.");
+            return;
+        }
+
+        // Shouldn't be possible to launch this action in image set mode, because we only
+        // add the menu item in file system mode, but let's be sure about it:
+        if (MainWindow.getInstance().getBrowseMode() != MainWindow.BrowseMode.FILE_SYSTEM) {
+            MainWindow.getInstance().showMessageDialog(NAME,
+                                                       "Auto-tag batch is only available in file system browse mode.");
+            return;
+        }
+
+        // Make sure we have good LLM configuration before proceeding,
+        // and disable the "warn if no tag restrictions" option, as we will allow the user to override that anyway:
+        AiConnectionManager aiManager = new AiConnectionManager(requestTemplate, requestTemplateTagless, false);
+        if (!aiManager.isFeatureEnabled()) {
+            MainWindow.getInstance().showMessageDialog(NAME,
+                                                       "Auto-tag batch is not available because the LLM connection is not properly configured." +
+                                                               "\nVisit the Auto-tag settings page in application properties to set it up.");
+            return;
+        }
+
+        new AutoTagBatchDialog(MainWindow.getInstance(), dir, aiManager).setVisible(true);
+    }
+}

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiConnectionManager.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiConnectionManager.java
@@ -187,7 +187,7 @@ public class AiConnectionManager {
      * Be sure the user is aware of this! Otherwise it may be confusing why
      * the restriction list in application properties is being ignored.
      * <p>
-     * null is a special value here - it mean "reload whatever is in AppConfig".
+     * null is a special value here - it means "reload whatever is in AppConfig".
      * If you want to override AppConfig with an empty list, don't pass null!
      * Just pass an empty TagList.
      * </p>

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiConnectionManager.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiConnectionManager.java
@@ -191,10 +191,17 @@ public class AiConnectionManager {
      * If you want to override AppConfig with an empty list, don't pass null!
      * Just pass an empty TagList.
      * </p>
+     * <p>
+     * <b>Note:</b> invoking this method when the feature is disabled does nothing.
+     * </p>
      */
     public void setLlmTags(TagList newTags) {
-        llmTags.clear();
+        // Do nothing if the feature is disabled, or if our tag list was never initialized due to bad config:
+        if (llmTags == null || !featureEnabled) {
+            return;
+        }
 
+        llmTags.clear();
         if (newTags == null) {
             // Reload from AppConfig, if anything is configured there.
             PropertiesManager propsManager = AppConfig.getInstance().getPropertiesManager();

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiConnectionManager.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiConnectionManager.java
@@ -25,10 +25,6 @@ import java.util.logging.Logger;
  *     <li>Right now we're using template json from our jar resources and just search and replacing certain keys
  *         to form the request. This works, but is overly simplistic. We should probably use the openai-java
  *         library instead of forming raw REST requests ourselves.</li>
- *     <li>Currently, you can only request an auto-tag for the selected image. It would be great to
- *         have a "batch mode", where it goes through all images in a directory, with optional recursion.</li>
- *     <li>Currently, the auto-tag can only be triggered from a configurable keyboard shortcut. It would be
- *         nice to have a menu item or toolbar button or right-click popup option or something.</li>
  * </ul>
  * <p>
  *     The above TODOs will be handled in future tickets, if the initial proof-of-concept works out.
@@ -58,6 +54,7 @@ public class AiConnectionManager {
     private String llmModel;
     private String llmApiKey;
     private TagList llmTags;
+    private final boolean warnUnrestricted;
 
     /**
      * If the LLM is unable to determine tags for some reason (the image is unclear, the given tag
@@ -69,6 +66,10 @@ public class AiConnectionManager {
     public static final String KEY_MODEL = "{{MODEL}}";
     public static final String KEY_IMG_DATA = "{{IMGDATA}}";
     public static final String KEY_TAGS = "{{TAGS}}";
+
+    public AiConnectionManager(String jsonTemplate, String jsonTemplateTagless) {
+        this(jsonTemplate, jsonTemplateTagless, true);
+    }
 
     /**
      * The two json template strings must be supplied here (they do not change dynamically).
@@ -85,15 +86,27 @@ public class AiConnectionManager {
      *
      * @param jsonTemplate        The json template for a tag-constrained analysis request. If blank, the feature is disabled.
      * @param jsonTemplateTagless The json template for a tagless analysis request. If blank, the feature is disabled.
+     * @param warnUnrestricted    Emits a log warning if no tag restrictions are set in application properties.
      */
-    public AiConnectionManager(String jsonTemplate, String jsonTemplateTagless) {
+    public AiConnectionManager(String jsonTemplate, String jsonTemplateTagless, boolean warnUnrestricted) {
         this.jsonTemplate = jsonTemplate;
         this.jsonTemplateTagless = jsonTemplateTagless;
+        this.warnUnrestricted = warnUnrestricted;
 
         // We'll load this here in the constructor.
         // Our assumption is that this class is instantiated on demand, rather than keeping an instance around.
         // So, we don't need to wire up to the UIReload mechanism to watch for config changes.
         populateConfig();
+    }
+
+    /**
+     * Reports whether we have good configuration to make LLM requests.
+     * This does not guarantee that the LLM is reachable! We don't actually validate the
+     * connection until request time. This method simply checks our config to make sure
+     * we have what we need to attempt a connection.
+     */
+    public boolean isFeatureEnabled() {
+        return featureEnabled;
     }
 
     /**
@@ -169,6 +182,33 @@ public class AiConnectionManager {
     }
 
     /**
+     * By default, this manager will load the restricted tag list from AppConfig.
+     * But you can override it, if you have your own restriction list.
+     * Be sure the user is aware of this! Otherwise it may be confusing why
+     * the restriction list in application properties is being ignored.
+     * <p>
+     * null is a special value here - it mean "reload whatever is in AppConfig".
+     * If you want to override AppConfig with an empty list, don't pass null!
+     * Just pass an empty TagList.
+     * </p>
+     */
+    public void setLlmTags(TagList newTags) {
+        llmTags.clear();
+
+        if (newTags == null) {
+            // Reload from AppConfig, if anything is configured there.
+            PropertiesManager propsManager = AppConfig.getInstance().getPropertiesManager();
+            AbstractProperty prop = propsManager.getProperty(IceExtension.llmTagsProp);
+            if (prop instanceof ShortTextProperty tagsProp) {
+                llmTags.addAll(TagList.of(tagsProp.getValue()));
+            }
+        }
+        else {
+            llmTags.addAll(newTags);
+        }
+    }
+
+    /**
      * Grabs our config from AppConfig and validates it.
      * This will set featureEnabled to false if our config is invalid.
      */
@@ -237,7 +277,7 @@ public class AiConnectionManager {
         prop = propsManager.getProperty(IceExtension.llmTagsProp);
         if (prop instanceof ShortTextProperty tagsProp) {
             llmTags = TagList.of(tagsProp.getValue()); // TagList can parse this for us
-            if (llmTags.isEmpty()) {
+            if (llmTags.isEmpty() && warnUnrestricted) {
                 // This may result in very unexpected behavior. Perhaps the user is unaware of the consequences here:
                 log.warning("LLM tags list is empty - the LLM will be free to choose any tags it wants!" +
                                     " This may result in unpredictable or inconsistent tags being chosen. " +

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiRequestThread.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiRequestThread.java
@@ -36,6 +36,7 @@ public class AiRequestThread extends SimpleProgressWorker {
     private final AiConnectionManager manager;
     private final AiConnectionManager.CompletionCallback onComplete;
     private final AiConnectionManager.ErrorCallback onError;
+    private boolean chatty;
 
     public AiRequestThread(File imageFile,
                            AiConnectionManager manager,
@@ -45,6 +46,22 @@ public class AiRequestThread extends SimpleProgressWorker {
         this.onComplete = onComplete;
         this.onError = onError;
         this.imageFile = imageFile;
+        chatty = true;
+    }
+
+    /**
+     * Reports whether this thread will emit log messages during request execution.
+     */
+    public boolean isChatty() {
+        return chatty;
+    }
+
+    /**
+     * By default, this thread will log success/failure messages regarding the request.
+     * If you plan to do your own logging, you can tell this thread to be quiet by setting chatty to false.
+     */
+    public void setChatty(boolean chatty) {
+        this.chatty = chatty;
     }
 
     @Override
@@ -98,16 +115,20 @@ public class AiRequestThread extends SimpleProgressWorker {
                     try {
                         // We can try to parse out what happened:
                         AiErrorBody errorBody = objectMapper.readValue(response.body(), AiErrorBody.class);
-                        log.severe("LLM request failed with status code " + response.statusCode() + ": "
-                                           + errorBody.getMessage() + " (code " + errorBody.getCode() + ", type "
-                                           + errorBody.getType() + ")");
+                        if (chatty) {
+                            log.severe("LLM request failed with status code " + response.statusCode() + ": "
+                                               + errorBody.getMessage() + " (code " + errorBody.getCode() + ", type "
+                                               + errorBody.getType() + ")");
+                        }
                         onError.onError(errorBody);
                     }
                     catch (Exception e) {
                         // We were unable to parse it, so best we can do is show the generic error code:
                         // (we *could* log the response body, but it might be huge, and it might leak
                         //  server info into the log, so we'll just let it go)
-                        log.severe("LLM request failed with status code " + response.statusCode());
+                        if (chatty) {
+                            log.severe("LLM request failed with status code " + response.statusCode());
+                        }
                         onError.onError(AiErrorBody.of(response.statusCode(),
                                                        "HTTP error",
                                                        "LLM request failed with status code " + response.statusCode()));
@@ -117,11 +138,15 @@ public class AiRequestThread extends SimpleProgressWorker {
 
                 // We'll use Jackson to parse the json response:
                 AiCompletionsBody responseObject = objectMapper.readValue(response.body(), AiCompletionsBody.class);
-                log.info("Auto-tag: received response from LLM: finish_reason=" + responseObject.getFinishReason()
-                                 + ", output=" + responseObject.getOutput());
+                if (chatty) {
+                    log.info("Auto-tag: received response from LLM: finish_reason=" + responseObject.getFinishReason()
+                                     + ", output=" + responseObject.getOutput());
+                }
                 TagList results = responseObject.getOutput();
                 if (results.isEmpty()) {
-                    log.warning("LLM response did not contain any tags. Returning NO_TAGS.");
+                    if (chatty) {
+                        log.warning("LLM response did not contain any tags. Returning NO_TAGS.");
+                    }
                     onComplete.onComplete(noTags());
                 }
                 else {
@@ -129,7 +154,9 @@ public class AiRequestThread extends SimpleProgressWorker {
                 }
             }
             catch (Exception e) {
-                log.log(Level.SEVERE, "Failed to send LLM request or parse response: " + e.getMessage(), e);
+                if (chatty) {
+                    log.log(Level.SEVERE, "Failed to send LLM request or parse response: " + e.getMessage(), e);
+                }
                 onError.onError(AiErrorBody.of(e.getClass().getName(),
                                                "Failed to send LLM request or parse response: " + e.getMessage()));
             }

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/AutoTagBatchDialog.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/AutoTagBatchDialog.java
@@ -1,0 +1,342 @@
+package ca.corbett.imageviewer.extensions.ice.ui.dialogs;
+
+import ca.corbett.extras.io.FileSystemUtil;
+import ca.corbett.extras.progress.MultiProgressDialog;
+import ca.corbett.extras.progress.SimpleProgressWorker;
+import ca.corbett.extras.properties.AbstractProperty;
+import ca.corbett.extras.properties.PropertiesManager;
+import ca.corbett.extras.properties.ShortTextProperty;
+import ca.corbett.forms.Alignment;
+import ca.corbett.forms.FormPanel;
+import ca.corbett.forms.fields.CheckBoxField;
+import ca.corbett.forms.fields.LabelField;
+import ca.corbett.forms.fields.ShortTextField;
+import ca.corbett.imageviewer.AppConfig;
+import ca.corbett.imageviewer.extensions.ice.IceExtension;
+import ca.corbett.imageviewer.extensions.ice.TagIndex;
+import ca.corbett.imageviewer.extensions.ice.TagList;
+import ca.corbett.imageviewer.extensions.ice.llm.AiConnectionManager;
+import ca.corbett.imageviewer.extensions.ice.llm.AiErrorBody;
+import ca.corbett.imageviewer.extensions.ice.llm.AiRequestThread;
+import ca.corbett.imageviewer.ui.MainWindow;
+import org.apache.commons.io.FilenameUtils;
+
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import java.awt.BorderLayout;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * Shows a dialog that allows auto-tagging of all jpeg and/or png images in the selected
+ * directory, with optional recursion. This feature is experimental and subject to change!
+ * <p>
+ * Note that batch auto-tagging, unlike single-image auto-tagging, will automatically update
+ * the affected image(s) with the suggested tags, with no opportunity to review or edit them.
+ * This is a bit of a YOLO option, especially if you have not constrained the LLM with
+ * a restricted tag list. If any auto-tag request fails, the batch is aborted. Tags that
+ * have already been applied at that point in the operation have already been saved.
+ * (There is no "transaction rollback" option here... maybe a future feature).
+ * Same thing applies if the batch operation is canceled - all tags that have already
+ * been received from the LLM at that point are already saved. "Cancel" just stops
+ * the operation from proceeding any further.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since 3.3.0
+ */
+public class AutoTagBatchDialog extends JDialog {
+
+    private static final Logger log = Logger.getLogger(AutoTagBatchDialog.class.getName());
+    private static final String NAME = "Auto-tag batch";
+
+    private final AiConnectionManager aiManager;
+    private final File dir;
+    private final List<File> eligibleImages = new ArrayList<>();
+    private final CheckBoxField recursiveField;
+    private final LabelField imageCountLabel;
+    private final ShortTextField tagRestrictionField;
+    private boolean isOperationInProgress;
+
+    public AutoTagBatchDialog(Frame owner, File dir, AiConnectionManager aiManager) {
+        super(owner, NAME, true);
+        this.dir = dir;
+        this.aiManager = aiManager;
+        recursiveField = new CheckBoxField("Include subdirectories", true);
+        recursiveField.addValueChangedListener(e -> rescan());
+        imageCountLabel = new LabelField("Image count:", "0");
+        imageCountLabel.setHelpText("Note: Only JPEG and PNG images are counted here.");
+        tagRestrictionField = new ShortTextField("Tag restriction", 20);
+        tagRestrictionField.setHelpText("<html>Optional: restrict the LLM to only these tags." +
+                                                "<br>If blank, the LLM is free to decide which tags to use.</html>");
+        tagRestrictionField.setText(getRestrictionList());
+        FormPanel formPanel = new FormPanel(Alignment.TOP_LEFT);
+        formPanel.setBorderMargin(16);
+        formPanel.add(List.of(
+                recursiveField,
+                imageCountLabel,
+                tagRestrictionField
+        ));
+
+        setLayout(new BorderLayout());
+        add(formPanel, BorderLayout.CENTER);
+        add(buildButtonPanel(), BorderLayout.SOUTH);
+
+        setSize(600, 240);
+        setResizable(false);
+        setLocationRelativeTo(owner);
+        setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
+
+        // Force an immediate rescan to populate the image count:
+        rescan();
+    }
+
+    /**
+     * Executes a search of the current directory to find all eligible images.
+     * We want to do this before the user starts the operation, so they have some
+     * idea of how many requests they're about to make. The token usage might
+     * be considerable, so we should give them a heads-up in advance.
+     */
+    private void rescan() {
+        if (dir == null || !dir.isDirectory()) {
+            log.warning("No directory selected.");
+            return;
+        }
+
+        // If a scan or a batch operation is already in progress, ignore this request
+        if (isOperationInProgress) {
+            log.fine("Operation already in progress, ignoring rescan request.");
+            return;
+        }
+
+        // Set the flag to prevent concurrent scans:
+        isOperationInProgress = true;
+
+        // Fire off a worker thread as the scan may take some time:
+        boolean isRecursive = recursiveField.isChecked();
+        MultiProgressDialog progressDialog = new MultiProgressDialog(this, "Scanning directory...");
+        progressDialog.runWorker(new ScanWorker(dir, isRecursive), true);
+    }
+
+    /**
+     * Starts a worker thread to do the batch auto-tagging.
+     */
+    private void doBatch() {
+        // Quick sanity check: if we have no images, there's nothing we can do here:
+        if (eligibleImages.isEmpty()) {
+            MainWindow.getInstance().showMessageDialog(NAME,
+                                                       "No eligible images found in the selected directory.");
+            log.info("No eligible images found, aborting batch auto-tag.");
+            return;
+        }
+
+        // If a scan or a batch operation is already in progress, ignore this request:
+        if (isOperationInProgress) {
+            log.fine("Operation already in progress, ignoring request.");
+            return;
+        }
+
+        // Override the tag restriction list if the user has given us a custom value here:
+        TagList customRestrictionList = TagList.of(tagRestrictionField.getText());
+        if (customRestrictionList.isEmpty()) {
+            aiManager.setLlmTags(null); // null means "use whatever is in AppConfig"
+        }
+        else {
+            aiManager.setLlmTags(customRestrictionList);
+        }
+
+        // Emit a log warning if there are no tag restrictions (either in AppConfig or here)
+        if (aiManager.getLlmTags().isEmpty()) {
+            // This may result in very unexpected behavior. Perhaps the user is unaware of the consequences here:
+            log.warning("LLM tags list is empty - the LLM will be free to choose any tags it wants!" +
+                                " This may result in unpredictable or inconsistent tags being chosen. " +
+                                "You can supply a tag list in configuration to restrict the LLM.");
+        }
+
+        // Set the flag to prevent concurrent batch operations:
+        isOperationInProgress = true;
+
+        // Fire off a BatchWorker:
+        MultiProgressDialog progressDialog = new MultiProgressDialog(this, "Auto-tagging images...");
+        progressDialog.runWorker(new BatchWorker(eligibleImages), true);
+    }
+
+    /**
+     * Returns the configured restricted tag list from application settings.
+     * Will return a blank string if the user has not configured any.
+     */
+    private String getRestrictionList() {
+        PropertiesManager propsManager = AppConfig.getInstance().getPropertiesManager();
+        AbstractProperty prop = propsManager.getProperty(IceExtension.llmTagsProp);
+        String restrictedTags = "";
+        if (prop instanceof ShortTextProperty tagsProp) {
+            restrictedTags = tagsProp.getValue();
+        }
+        return restrictedTags;
+    }
+
+    private JPanel buildButtonPanel() {
+        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        buttonPanel.setBorder(BorderFactory.createRaisedBevelBorder());
+
+        JButton button = new JButton("Rescan");
+        button.setPreferredSize(new Dimension(100, 25));
+        button.addActionListener(e -> rescan());
+        buttonPanel.add(button);
+
+        button = new JButton("Auto-tag!");
+        button.setPreferredSize(new Dimension(100, 25));
+        button.addActionListener(e -> doBatch());
+        buttonPanel.add(button);
+
+        button = new JButton("Cancel");
+        button.setPreferredSize(new Dimension(100, 25));
+        button.addActionListener(e -> dispose());
+        buttonPanel.add(button);
+
+        return buttonPanel;
+    }
+
+    /**
+     * A very simple worker to wrap the FileSystemUtil findFiles call, which may take some time
+     * if we're in a very large directory. The thread updates our image count label, and also
+     * populates the eligibleImages list, which we will use later when we do the batch auto-tagging.
+     * Only one scan can be in progress at a time, as enforced by the isScanInProgress flag.
+     */
+    private class ScanWorker extends SimpleProgressWorker {
+
+        private final File dir;
+        private final boolean isRecursive;
+
+        public ScanWorker(File dir, boolean isRecursive) {
+            this.dir = dir;
+            this.isRecursive = isRecursive;
+        }
+
+        @Override
+        public void run() {
+            fireProgressBegins(2);
+            try {
+                fireProgressUpdate(1, "Scanning for images...");
+                List<File> images = FileSystemUtil.findFiles(dir, isRecursive, List.of("jpg", "jpeg", "png"));
+
+                SwingUtilities.invokeLater(() -> imageCountLabel.setText(String.valueOf(images.size())));
+                eligibleImages.clear();
+                eligibleImages.addAll(images);
+            }
+            finally {
+                SwingUtilities.invokeLater(() -> {
+                    isOperationInProgress = false;
+                });
+
+                fireProgressComplete(); // make sure the progress dialog closes
+            }
+        }
+    }
+
+    /**
+     * A worker thread to spawn an AiRequestThread for each eligible image, one by one, and track
+     * their progress. In theory, we could send multiple requests at a time to the LLM server,
+     * but we might hit rate-limiting errors. Also, by doing it one-by-one, we have the option
+     * of aborting the batch if any of the requests fails. This is a debatable call, but as
+     * this is an experimental feature, I think it's fine for now.
+     */
+    private class BatchWorker extends SimpleProgressWorker {
+
+        private final List<File> imagesToProcess;
+
+        public BatchWorker(List<File> imagesToProcess) {
+            // Make a copy of the list to avoid concurrency issues:
+            this.imagesToProcess = new ArrayList<>(imagesToProcess);
+        }
+
+        private void handleResult(File imageFile, TagList tagList) {
+            // An "empty" return is one where we got back either a completely empty list,
+            // or a list with just the NO_TAG sentinel value.
+            boolean isEmpty = tagList.isEmpty()
+                    || (tagList.size() == 1 && tagList.getTags().get(0).equals(AiConnectionManager.NO_TAGS));
+
+            // If we get back such a list, just log it and move on:
+            if (isEmpty) {
+                log.info("Auto-tag: "
+                                 + imageFile.getAbsolutePath()
+                                 + ": The LLM had no tag suggestions for this image.");
+                return;
+            }
+
+            // Find the tag file for this image.
+            // It's not an error if this file does not exist... we'll create it.
+            log.info("Auto-tag: " + imageFile.getAbsolutePath() + ": adding tags: " + tagList.toString());
+            File tagFile = new File(imageFile.getParentFile(), FilenameUtils.getBaseName(imageFile.getName()) + ".ice");
+            TagList originalTags = TagList.fromFile(tagFile); // might be empty; that's okay
+            originalTags.addAll(tagList); // duplicates are pruned automatically, it's not a problem.
+            originalTags.save(); // commit changes to disk
+            TagIndex.getInstance().addOrUpdateEntry(imageFile, tagFile); // tell the TagIndex of this change
+        }
+
+        private void handleError(File imageFile, AiErrorBody error) {
+            log.severe("Auto-tag operation failed: " + error.getMessage()
+                               + " (code: " + error.getCode() + ", type: " + error.getType() + ")");
+
+            // If any request fails, we will abort the entire batch and show an error message to the user.
+            SwingUtilities.invokeLater(() -> {
+                MainWindow.getInstance().showMessageDialog(NAME,
+                                                           "Error auto-tagging image: " + imageFile.getName() +
+                                                                   "\nError code: " + error.getCode() +
+                                                                   "\nMessage: " + error.getMessage() +
+                                                                   "\nError type: " + error.getType() +
+                                                                   "\n\nAborting batch operation.");
+            });
+
+            // We can break out of the loop here, which will cause the batch operation to end.
+            // The isOperationInProgress flag will be reset in the finally block, allowing the user to try again if they want.
+            throw new RuntimeException("Batch auto-tagging aborted due to error.");
+        }
+
+        @Override
+        public void run() {
+            fireProgressBegins(imagesToProcess.size());
+            int step = 0;
+            try {
+                for (File imageFile : imagesToProcess) {
+                    if (!fireProgressUpdate(step++, imageFile.getAbsolutePath())) {
+                        log.info("Batch auto-tagging cancelled by user.");
+                        break;
+                    }
+
+                    AiRequestThread thread = new AiRequestThread(imageFile,
+                                                                 aiManager,
+                                                                 tagList -> handleResult(imageFile, tagList),
+                                                                 errorBody -> handleError(imageFile, errorBody));
+                    thread.setChatty(false); // quiet, you!
+                    thread.run(); // run the request synchronously in this worker thread, so we can track progress and handle errors appropriately
+                }
+
+                // We'll add a slight, 1s delay between requests, to avoid hammering the server.
+                // Would this help avoid rate-limiting errors? Dunno, maybe. Just seems polite though.
+                Thread.sleep(1000);
+            }
+            catch (Exception e) {
+                log.severe("Batch auto-tagging failed: " + e.getMessage());
+                // The error has already been handled in the handleError method, so we don't need to do anything else here.
+            }
+            finally {
+                SwingUtilities.invokeLater(() -> {
+                    isOperationInProgress = false;
+                    MainWindow.getInstance().reload(); // Reload current dir to show new tags
+                    dispose(); // debatable, but probably makes sense to close after a successful batch operation.
+                });
+
+                fireProgressComplete(); // make sure the progress dialog closes
+            }
+        }
+    }
+}

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/AutoTagBatchDialog.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/AutoTagBatchDialog.java
@@ -322,11 +322,11 @@ public class AutoTagBatchDialog extends JDialog {
                                                                  errorBody -> handleError(imageFile, errorBody));
                     thread.setChatty(false); // quiet, you!
                     thread.run(); // run the request synchronously in this worker thread, so we can track progress and handle errors appropriately
-                }
 
-                // We'll add a slight, 1s delay between requests, to avoid hammering the server.
-                // Would this help avoid rate-limiting errors? Dunno, maybe. Just seems polite though.
-                Thread.sleep(1000);
+                    // We'll add a slight, 1s delay between requests, to avoid hammering the server.
+                    // Would this help avoid rate-limiting errors? Dunno, maybe. Just seems polite though.
+                    Thread.sleep(1000);
+                }
             }
             catch (Exception e) {
                 log.severe("Batch auto-tagging failed: " + e.getMessage());

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/AutoTagBatchDialog.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/AutoTagBatchDialog.java
@@ -63,6 +63,7 @@ public class AutoTagBatchDialog extends JDialog {
     private final List<File> eligibleImages = new ArrayList<>();
     private final CheckBoxField recursiveField;
     private final LabelField imageCountLabel;
+    private final CheckBoxField useConfigRestrictionField;
     private final ShortTextField tagRestrictionField;
     private boolean isOperationInProgress;
 
@@ -75,14 +76,19 @@ public class AutoTagBatchDialog extends JDialog {
         imageCountLabel = new LabelField("Image count:", "0");
         imageCountLabel.setHelpText("Note: Only JPEG and PNG images are counted here.");
         tagRestrictionField = new ShortTextField("Tag restriction", 20);
-        tagRestrictionField.setHelpText("<html>Optional: restrict the LLM to only these tags." +
+        tagRestrictionField.setHelpText("<html>Restrict the LLM to only these tags." +
                                                 "<br>If blank, the LLM is free to decide which tags to use.</html>");
+        tagRestrictionField.setEnabled(false);
         tagRestrictionField.setText(getRestrictionList());
+        useConfigRestrictionField = new CheckBoxField("Use tag restrictions from configuration", true);
+        useConfigRestrictionField.addValueChangedListener(
+                e -> tagRestrictionField.setEnabled(!useConfigRestrictionField.isChecked()));
         FormPanel formPanel = new FormPanel(Alignment.TOP_LEFT);
         formPanel.setBorderMargin(16);
         formPanel.add(List.of(
                 recursiveField,
                 imageCountLabel,
+                useConfigRestrictionField,
                 tagRestrictionField
         ));
 
@@ -145,15 +151,13 @@ public class AutoTagBatchDialog extends JDialog {
         }
 
         // Override the tag restriction list if the user has given us a custom value here:
-        TagList customRestrictionList = TagList.of(tagRestrictionField.getText());
-        if (customRestrictionList.isEmpty()) {
-            aiManager.setLlmTags(null); // null means "use whatever is in AppConfig"
+        TagList restrictionTags = TagList.of(getRestrictionList()); // might be empty
+        if (!useConfigRestrictionField.isChecked()) {
+            restrictionTags = TagList.of(tagRestrictionField.getText()); // might be empty
         }
-        else {
-            aiManager.setLlmTags(customRestrictionList);
-        }
+        aiManager.setLlmTags(restrictionTags); // okay if empty - LLM will choose tags
 
-        // Emit a log warning if there are no tag restrictions (either in AppConfig or here)
+        // Emit a log warning if there are no tag restrictions:
         if (aiManager.getLlmTags().isEmpty()) {
             // This may result in very unexpected behavior. Perhaps the user is unaware of the consequences here:
             log.warning("LLM tags list is empty - the LLM will be free to choose any tags it wants!" +

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/AutoTagBatchDialog.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/AutoTagBatchDialog.java
@@ -213,7 +213,7 @@ public class AutoTagBatchDialog extends JDialog {
      * A very simple worker to wrap the FileSystemUtil findFiles call, which may take some time
      * if we're in a very large directory. The thread updates our image count label, and also
      * populates the eligibleImages list, which we will use later when we do the batch auto-tagging.
-     * Only one scan can be in progress at a time, as enforced by the isScanInProgress flag.
+     * Only one scan can be in progress at a time, as enforced by the isOperationInProgress flag.
      */
     private class ScanWorker extends SimpleProgressWorker {
 

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
@@ -3,6 +3,7 @@ Author: Steve Corbett
 
 Version 3.3.0 [TODO: release date]
   #79 - Auto-tag: add suggested tag preview dialog
+  #78 - Auto-tag: add batch mode
   #77 - Auto-tag: improved error handling and reporting
   #73 - add auto-tag support via LLM (highly experimental!)
 


### PR DESCRIPTION
This PR addresses issue #78 by adding a batch option for the Auto-tag feature. In batch mode, an entire directory of images can be auto-tagged, with optional recursion. Batch mode is available only in "file system" browse mode. 

The user is given the option to override the currently-configured tag restriction list. This is handy when tagging a specific directory with its own unique tag requirements. 

Images are tagged sequentially rather than in parallel, to avoid possible rate-limiting problems with some LLM providers. A progress bar with a cancel button is provided, so that the operation can be aborted (albeit without rollback for tags already applied).