### PR TITLE
Issue #86: Auto-tag: add support for OPENAI_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ The following configuration can be specified:
   `http://localhost:8080` or `https://my-llm-provider.com`. Don't enter the path information (`v1/chat/completions` for
   example).
 - **LLM API key** - if your LLM provider requires an API key, you can enter it here. If not required, leave blank.
-  Warning: any value you enter here will be saved in plain text in the application properties file!
+  Warning: any value you enter here will be saved in plain text in the application properties file! If you don't want
+  that, you can specify the `OPENAI_API_KEY` environment variable instead, and leave this value blank. The application
+  will get the value to use from the environment.
 - **LLM model name** - the name of the model to use for auto-tagging. Not all servers require this value.
 - **LLM tag list** - an optional list of tags that the LLM will be constrained to choose from. You can leave this blank
   to allow the LLM to decide on its own tags, but be aware that the results may be unpredictable and inconsistent from

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiConnectionManager.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiConnectionManager.java
@@ -270,10 +270,37 @@ public class AiConnectionManager {
         }
         prop = propsManager.getProperty(IceExtension.llmApiKeyProp);
         if (prop instanceof PasswordProperty apiKeyProp) {
-            llmApiKey = apiKeyProp.getPassword().trim();
+            // Order of precedence for API key: The environment variable always overrides
+            // whatever you specify in props. We only use the value from props if there's
+            // nothing set in the environment. This allows the user to leave the API key
+            // blank in our props entirely. That's good, because we store everything as plain text.
+            // The env var is safer.
+            String apiKeyFromProps = apiKeyProp.getPassword().trim();
+            String apiKeyFromEnv = System.getenv("OPENAI_API_KEY");
+            if (apiKeyFromEnv != null && !apiKeyFromEnv.isBlank()) {
+
+                // Wonky case: if it's set in both locations, and the values don't match,
+                // log a warning, because that's suspicious:
+                if (!apiKeyFromProps.isEmpty() && !apiKeyFromEnv.equals(apiKeyFromProps)) {
+                    log.warning("LLM API key is set in both environment variable and application properties," +
+                                        " but the values do not match! Using the value from the environment variable. " +
+                                        "You may want to check your configuration.");
+                }
+
+                llmApiKey = apiKeyFromEnv;
+            }
+            else {
+                // Fall back to whatever we got from props if it isn't in the env var:
+                llmApiKey = apiKeyFromProps;
+            }
+
+            // If we didn't find one at all, we'll emit a fine log warning:
             if (llmApiKey.isEmpty()) {
-                // This is not necessarily a problem, but we have no way of knowing if the server requires it or not:
-                // Again, we could log this, but it feels noisy. If the user gets a 401, they'll know why.
+                // This is not necessarily a problem, but we have no way of knowing if the server requires it or not.
+                // Again, we could log this at WARNING level, but it feels noisy.
+                // We'll log it at FINE level for anyone who's debugging their config.
+                // (in my testing, the error message usually says "wrong api key", with an error
+                //  type of "authentication_error", so it should be easy to understand what went wrong)
                 log.fine("LLM API key is blank - if authentication is required, requests will fail.");
             }
         }

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
@@ -2,6 +2,7 @@ ext-iv-ice Release Notes
 Author: Steve Corbett
 
 Version 3.3.0 [TODO: release date]
+  #86 - Auto-tag: add support for OPENAI_API_KEY env var
   #83 - Update README for the new auto-tag feature
   #79 - Auto-tag: add suggested tag preview dialog
   #78 - Auto-tag: add batch mode


### PR DESCRIPTION
This PR addresses issue #86 by adding optional support for the `OPENAI_API_KEY` environment variable. If set, this overrides whatever API key the user has specified in our configuration properties. This also allows the user to leave the value entirely blank in our application properties - this is better security, because our app properties file is stored as plain text.

The order of precedence is such that the environment variable always wins, if it is set. 

I'm making an executive decision to NOT emit a log message at the warn level if no api key is found. This might in fact be perfectly normal, for example in a local LLM setup where authentication is not required. We still log it at the FINE level to help with troubleshooting.