### PR TITLE
Issue #89 - Auto-tag: make connect/request timeouts configurable

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
@@ -118,6 +118,8 @@ public class IceExtension extends ImageViewerExtension implements UIReloadable {
     public static final String autoTagBatchKeyProp = "ICE.Auto-tag.autoTagBatchHotKey";
     public static final String sysPromptTaggedProp = "ICE.Auto-tag.sysPromptTagged";
     public static final String sysPromptTaglessProp = "ICE.Auto-tag.sysPromptTagless";
+    public static final String llmConnectTimeoutProp = "ICE.Auto-tag.llmConnectTimeout";
+    public static final String llmRequestTimeoutProp = "ICE.Auto-tag.llmRequestTimeout";
 
     private final List<TagPreviewPanel> tagPreviewPanels = new ArrayList<>();
     private final List<QuickTagPanel> quickTagPanels = new ArrayList<>();
@@ -213,6 +215,10 @@ public class IceExtension extends ImageViewerExtension implements UIReloadable {
                          .setPassword("")
                          .setHelpText("<html>Your API key for the LLM server.<br>" +
                                               "Not needed for some servers, like a local LLaMA instance.</html>"));
+        list.add(new ComboProperty<>(llmConnectTimeoutProp, "Connect timeout:", getConnectTimeoutOptions(), 1,
+                                     false));
+        list.add(new ComboProperty<>(llmRequestTimeoutProp, "Request timeout:", getRequestTimeoutOptions(), 1,
+                                     false));
         list.add(new ShortTextProperty(llmModelProp, "LLM model name:", "gpt-3.5-turbo")
                          .setAllowBlank(true) // blank means not needed for this server
                          .setHelpText("<html>The name of the model to use for tag generation.</html>"));
@@ -696,5 +702,63 @@ public class IceExtension extends ImageViewerExtension implements UIReloadable {
             // So, it's not an error if we get in here. Just return the supplied default.
             return defaultValue == null ? "" : defaultValue;
         }
+    }
+
+    /**
+     * Returns the list of options for the LLM connect timeout combo property.
+     */
+    private List<String> getConnectTimeoutOptions() {
+        return List.of("5 seconds", "10 seconds", "30 seconds", "60 seconds");
+    }
+
+    /**
+     * Returns the currently-configured LLM connect timeout in milliseconds.
+     */
+    public static int getConnectTimeoutMS() {
+        // Look up our config prop:
+        PropertiesManager propsManager = AppConfig.getInstance().getPropertiesManager();
+        AbstractProperty prop = propsManager.getProperty(IceExtension.llmConnectTimeoutProp);
+        if (prop instanceof ComboProperty<?> comboProp) {
+            int selectedIndex = comboProp.getSelectedIndex();
+            return switch (selectedIndex) {
+                case 0 -> 5000;
+                case 1 -> 10000;
+                case 2 -> 30000;
+                case 3 -> 60000;
+                default -> 10000; // default to 10 seconds if something goes wrong
+            };
+        }
+
+        return 10000; // default to 10 seconds if something goes wrong
+    }
+
+    /**
+     * Returns the list of options for the LLM request timeout combo property.
+     * These values are higher than the connect timeout options, because request
+     * processing can take much longer.
+     */
+    private List<String> getRequestTimeoutOptions() {
+        return List.of("30 seconds", "60 seconds", "120 seconds", "300 seconds");
+    }
+
+    /**
+     * Returns the currently-configured LLM request timeout in milliseconds.
+     */
+    public static int getRequestTimeoutMS() {
+        // Look up our config prop:
+        PropertiesManager propsManager = AppConfig.getInstance().getPropertiesManager();
+        AbstractProperty prop = propsManager.getProperty(IceExtension.llmRequestTimeoutProp);
+        if (prop instanceof ComboProperty<?> comboProp) {
+            int selectedIndex = comboProp.getSelectedIndex();
+            return switch (selectedIndex) {
+                case 0 -> 30000;
+                case 1 -> 60000;
+                case 2 -> 120000;
+                case 3 -> 300000;
+                default -> 60000; // default to 60 seconds if something goes wrong
+            };
+        }
+
+        return 60000; // default to 60 seconds if something goes wrong
     }
 }

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiRequestThread.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiRequestThread.java
@@ -1,6 +1,7 @@
 package ca.corbett.imageviewer.extensions.ice.llm;
 
 import ca.corbett.extras.progress.SimpleProgressWorker;
+import ca.corbett.imageviewer.extensions.ice.IceExtension;
 import ca.corbett.imageviewer.extensions.ice.TagList;
 import com.fasterxml.jackson.core.io.SerializedString;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -34,14 +35,13 @@ public class AiRequestThread extends SimpleProgressWorker {
 
     private static final Logger log = Logger.getLogger(AiRequestThread.class.getName());
 
-    private static final int CONNECT_TIMEOUT_SECONDS = 15;
-    private static final int REQUEST_TIMEOUT_SECONDS = 120;
-
     private final File imageFile;
     private final AiConnectionManager manager;
     private final AiConnectionManager.CompletionCallback onComplete;
     private final AiConnectionManager.ErrorCallback onError;
     private boolean chatty;
+    private long connectTimeoutMS;
+    private long requestTimeoutMS;
 
     public AiRequestThread(File imageFile,
                            AiConnectionManager manager,
@@ -52,6 +52,10 @@ public class AiRequestThread extends SimpleProgressWorker {
         this.onError = onError;
         this.imageFile = imageFile;
         chatty = true;
+
+        // Look up our timeout settings now, before the thread starts:
+        connectTimeoutMS = IceExtension.getConnectTimeoutMS();
+        requestTimeoutMS = IceExtension.getRequestTimeoutMS();
     }
 
     /**
@@ -106,12 +110,12 @@ public class AiRequestThread extends SimpleProgressWorker {
             try {
                 fireProgressUpdate(1, "Sending request to LLM...");
                 HttpClient client = HttpClient.newBuilder()
-                                              .connectTimeout(Duration.ofSeconds(CONNECT_TIMEOUT_SECONDS))
+                                              .connectTimeout(Duration.ofMillis(connectTimeoutMS))
                                               .build();
                 HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                                                                 .uri(url.toURI())
                                                                 .header("Content-Type", "application/json")
-                                                                .timeout(Duration.ofSeconds(REQUEST_TIMEOUT_SECONDS));
+                                                                .timeout(Duration.ofMillis(requestTimeoutMS));
                 if (!apiKey.isBlank()) {
                     requestBuilder.header("Authorization", "Bearer " + apiKey);
                 }

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
@@ -2,6 +2,7 @@ ext-iv-ice Release Notes
 Author: Steve Corbett
 
 Version 3.4.0 [TODO - release date]
+  #89 - Auto-tag: make connect/request timeouts configurable
   #88 - Auto-tag: make system prompts configurable
 
 Version 3.3.0 [2026-05-18]


### PR DESCRIPTION
This PR addresses issue #89 by exposing the connect and request timeouts for LLM connections configurable. Previously, hard-coded values were used. Now, the user can modify these values by choosing from a reasonable list of defaults. 

The previous baked-in defaults were 15s for connections and 120s for requests. The new defaults are 10s for connections and 60s for requests, but the user can change this if they wish.