### PR TITLE
Issue #91 Auto-tag: add threshold option for image downscale

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
@@ -113,6 +113,7 @@ public class IceExtension extends ImageViewerExtension implements UIReloadable {
     public static final String llmApiKeyProp = "ICE.Auto-tag.apiKey";
     public static final String llmModelProp = "ICE.Auto-tag.model";
     public static final String llmUrlProp = "ICE.Auto-tag.url";
+    public static final String llmDownscaleProp = "ICE.Auto-tag.downscaleForLLM";
     public static final String llmTagsProp = "ICE.Auto-tag.tags";
     public static final String autoTagKeyProp = "ICE.Auto-tag.autoTagHotKey";
     public static final String autoTagBatchKeyProp = "ICE.Auto-tag.autoTagBatchHotKey";
@@ -219,6 +220,9 @@ public class IceExtension extends ImageViewerExtension implements UIReloadable {
                                      false));
         list.add(new ComboProperty<>(llmRequestTimeoutProp, "Request timeout:", getRequestTimeoutOptions(), 1,
                                      false));
+        list.add(new ComboProperty<>(llmDownscaleProp, "Downscale when:", getLLMDownscaleOptions(), 2, false)
+                         .setHelpText("<html>The file on disk is not affected!<br>" +
+                                              "Downscaling makes LLM requests smaller and faster.</html>"));
         list.add(new ShortTextProperty(llmModelProp, "LLM model name:", "gpt-3.5-turbo")
                          .setAllowBlank(true) // blank means not needed for this server
                          .setHelpText("<html>The name of the model to use for tag generation.</html>"));
@@ -760,5 +764,36 @@ public class IceExtension extends ImageViewerExtension implements UIReloadable {
         }
 
         return 60000; // default to 60 seconds if something goes wrong
+    }
+
+    /**
+     * Returns the list of options for the auto-downscale combo property (for auto-tag requests).
+     */
+    private List<String> getLLMDownscaleOptions() {
+        return List.of("Image file > 512KB", "Image file > 1MB", "Image file > 2MB", "Image file > 5MB", "Never");
+    }
+
+    /**
+     * Returns the currently-configured LLM downscale threshold in bytes.
+     * If an image file is larger than this threshold, we will automatically
+     * downscale it before sending it to the LLM.
+     */
+    public static long getLLMDownscaleThresholdBytes() {
+        // Look up our config prop:
+        PropertiesManager propsManager = AppConfig.getInstance().getPropertiesManager();
+        AbstractProperty prop = propsManager.getProperty(IceExtension.llmDownscaleProp);
+        if (prop instanceof ComboProperty<?> comboProp) {
+            int selectedIndex = comboProp.getSelectedIndex();
+            return switch (selectedIndex) {
+                case 0 -> 512 * 1024;
+                case 1 -> 1024 * 1024;
+                case 2 -> 2 * 1024 * 1024;
+                case 3 -> 5 * 1024 * 1024;
+                case 4 -> Long.MAX_VALUE; // effectively "never", YOLO
+                default -> 2 * 1024 * 1024; // default to 2MB if something goes wrong
+            };
+        }
+
+        return 2 * 1024 * 1024; // default to 2MB if something goes wrong
     }
 }

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiRequestThread.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiRequestThread.java
@@ -260,8 +260,8 @@ public class AiRequestThread extends SimpleProgressWorker {
             int origW = original.getWidth();
             int origH = original.getHeight();
             double scaleRatio = Math.min(1.0, (double)maxDimension / Math.max(origW, origH));
-            int newW = (int)(origW * scaleRatio);
-            int newH = (int)(origH * scaleRatio);
+            int newW = Math.max(1, (int)(origW * scaleRatio));
+            int newH = Math.max(1, (int)(origH * scaleRatio));
 
             // Scale it in memory:
             scaledImage = new BufferedImage(newW, newH, BufferedImage.TYPE_INT_RGB);

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiRequestThread.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiRequestThread.java
@@ -279,6 +279,14 @@ public class AiRequestThread extends SimpleProgressWorker {
 
             // Convert to jpeg with a lower quality setting:
             imageBytes = toJpegBytesWithQuality(scaledImage, 0.75f);
+
+            // Wonky edge case: it might happen that our "downscaled" image is larger
+            // than the original. For example, a PNG image with a lot of flat colors.
+            // So, if the downscale failed, let's not use it:
+            if (imageBytes.length >= imageFile.length()) {
+                imageBytes = null; // screw it, let's just pretend this never happened
+            }
+
         }
         finally {
             if (scaledImage != null) {

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiRequestThread.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiRequestThread.java
@@ -1,11 +1,22 @@
 package ca.corbett.imageviewer.extensions.ice.llm;
 
+import ca.corbett.extras.image.ImageUtil;
+import ca.corbett.extras.io.FileSystemUtil;
 import ca.corbett.extras.progress.SimpleProgressWorker;
 import ca.corbett.imageviewer.extensions.ice.IceExtension;
 import ca.corbett.imageviewer.extensions.ice.TagList;
 import com.fasterxml.jackson.core.io.SerializedString;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import javax.imageio.IIOImage;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageOutputStream;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.net.URL;
 import java.net.http.HttpClient;
@@ -14,6 +25,7 @@ import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.util.Base64;
+import java.util.Iterator;
 import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -76,8 +88,11 @@ public class AiRequestThread extends SimpleProgressWorker {
     @Override
     public void run() {
         // Let's get the progress bar up:
-        // (2 steps: base64 encode the image, make the request)
-        fireProgressBegins(2);
+        // There are 3 steps:
+        //    1) downscale if necessary
+        //    2) base64 encode the image
+        //    3) make the request
+        fireProgressBegins(3);
         try {
 
             // These were validated by our AiManager, so we won't do it here again:
@@ -86,13 +101,33 @@ public class AiRequestThread extends SimpleProgressWorker {
             String apiKey = manager.getLlmApiKey();
             TagList tags = manager.getLlmTags();
 
-            // Base64-encode the image file:
-            fireProgressUpdate(0, "Encoding image...");
-            Base64.Encoder encoder = Base64.getEncoder();
+            // We'll start with the mime type of the original image:
             String base64ImageData;
+            String mimeType = imageFile.getName().toLowerCase(Locale.ROOT)
+                                       .endsWith(".png") ? "image/png" : "image/jpeg";
+
             try {
-                byte[] imageBytes = Files.readAllBytes(imageFile.toPath());
-                base64ImageData = encoder.encodeToString(imageBytes);
+                // Downscale the image if necessary (downscaleIfNecessary returns null if no downscale is needed):
+                fireProgressUpdate(0, "Downscale check...");
+                byte[] imageBytes = downscaleIfNecessary(imageFile);
+                if (imageBytes == null) {
+                    // No downscale needed! Just read the file as-is:
+                    imageBytes = Files.readAllBytes(imageFile.toPath());
+                }
+                else {
+                    // We downscaled it! Log this.
+                    // Executive decision: ignore the "chatty" setting, as this is important:
+                    String originalSize = FileSystemUtil.getPrintableSize(imageFile.length());
+                    String newSize = FileSystemUtil.getPrintableSize(imageBytes.length);
+                    log.info("Scaled oversized image from " + originalSize + " to " + newSize
+                                     + " - (original image file not affected). "
+                                     + "You can change the downscale threshold in application settings.");
+                    mimeType = "image/jpeg"; // Update the mime type since we converted to jpeg
+                }
+
+                // Base64-encode the image file:
+                fireProgressUpdate(1, "Encoding image...");
+                base64ImageData = Base64.getEncoder().encodeToString(imageBytes);
             }
             catch (Exception e) {
                 log.severe("Failed to read and encode image file: " + e.getMessage());
@@ -102,13 +137,11 @@ public class AiRequestThread extends SimpleProgressWorker {
             }
 
             // Do our tag substitution in our template to get the actual request body:
-            String mimeType = imageFile.getName().toLowerCase(Locale.ROOT)
-                                       .endsWith(".png") ? "image/png" : "image/jpeg";
             String jsonBody = prepareRequestBody(model, tags, base64ImageData, mimeType);
 
             // Now we can fire off the request and parse the response:
             try {
-                fireProgressUpdate(1, "Sending request to LLM...");
+                fireProgressUpdate(2, "Sending request to LLM...");
                 HttpClient client = HttpClient.newBuilder()
                                               .connectTimeout(Duration.ofMillis(connectTimeoutMS))
                                               .build();
@@ -205,5 +238,85 @@ public class AiRequestThread extends SimpleProgressWorker {
                       .replace(AiConnectionManager.KEY_IMG_DATA, base64ImageData)
                       .replace(AiConnectionManager.KEY_TAGS, safeTags)
                       .replace(AiConnectionManager.KEY_MIME_TYPE, mimeType);
+    }
+
+    /**
+     * Checks if the given image file exceeds our downscale threshold, and if so,
+     * downscales it in memory and returns the bytes of the downscaled image.
+     * Note that the returned byte array will always be JPEG image data!
+     * Update your mime type accordingly if this method returns non-null.
+     */
+    private static byte[] downscaleIfNecessary(File imageFile) throws Exception {
+        long downscaleThreshold = IceExtension.getLLMDownscaleThresholdBytes();
+        if (imageFile.length() <= downscaleThreshold) {
+            return null; // No downscale needed, caller can just read the original file bytes
+        }
+
+        BufferedImage scaledImage = null;
+        byte[] imageBytes;
+        try {
+            BufferedImage original = ImageUtil.loadImage(imageFile);
+            final int maxDimension = 2048; // Arbitrary choice here, but seems reasonable
+            int origW = original.getWidth();
+            int origH = original.getHeight();
+            double scaleRatio = Math.min(1.0, (double)maxDimension / Math.max(origW, origH));
+            int newW = (int)(origW * scaleRatio);
+            int newH = (int)(origH * scaleRatio);
+
+            // Scale it in memory:
+            scaledImage = new BufferedImage(newW, newH, BufferedImage.TYPE_INT_RGB);
+            Graphics2D g2d = scaledImage.createGraphics();
+            try {
+                g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                                     RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+                g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+                g2d.drawImage(original, 0, 0, newW, newH, null);
+            }
+            finally {
+                g2d.dispose();
+            }
+            original.flush();
+
+            // Convert to jpeg with a lower quality setting:
+            imageBytes = toJpegBytesWithQuality(scaledImage, 0.75f);
+        }
+        finally {
+            if (scaledImage != null) {
+                scaledImage.flush();
+            }
+        }
+
+        return imageBytes;
+    }
+
+    /**
+     * Helper method for downscaling. Always returns jpeg data, even if the input was a png!
+     * Make sure to update the mime type accordingly.
+     * <p>
+     * Should this move to swing-extras and live in the ImageUtil class? Seems awfully specific
+     * to this use case...
+     * </p>
+     *
+     * @param image   The image to convert to jpeg bytes.
+     * @param quality The jpeg quality to use - recommendation is 0.75f
+     */
+    private static byte[] toJpegBytesWithQuality(BufferedImage image, float quality) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        Iterator<ImageWriter> writers = ImageIO.getImageWritersByFormatName("jpg");
+        if (!writers.hasNext()) { throw new IllegalStateException("No JPEG writer found"); }
+
+        ImageWriter writer = writers.next();
+        ImageWriteParam params = writer.getDefaultWriteParam();
+        params.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+        params.setCompressionQuality(quality);
+
+        try (ImageOutputStream ios = ImageIO.createImageOutputStream(baos)) {
+            writer.setOutput(ios);
+            writer.write(null, new IIOImage(image, null, null), params);
+        }
+        finally {
+            writer.dispose();
+        }
+        return baos.toByteArray();
     }
 }

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
@@ -2,6 +2,7 @@ ext-iv-ice Release Notes
 Author: Steve Corbett
 
 Version 3.4.0 [TODO - release date]
+  #91 - Auto-tag: add threshold option for image downscaling
   #89 - Auto-tag: make connect/request timeouts configurable
   #88 - Auto-tag: make system prompts configurable
 


### PR DESCRIPTION
This PR addresses issue #91 by adding a new threshold option to trigger in-memory downscaling of images before sending them as base64-encoded data over an http connection. This is optional and can be disabled entirely by selecting `never` (the previous behavior). 

