### PR TITLE
Issue #94 - Auto-tag: fix bug with thinking data being returned in tag list

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiCompletionsBody.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiCompletionsBody.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import java.util.logging.Logger;
 
 /**
  * Represents a response body from the chat completions API.
@@ -40,6 +41,8 @@ import java.util.List;
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class AiCompletionsBody {
 
+    private static final Logger log = Logger.getLogger(AiCompletionsBody.class.getName());
+
     @JsonProperty("choices")
     private List<ChoiceNode> choices;
 
@@ -71,7 +74,20 @@ public class AiCompletionsBody {
         TagList allTags = new TagList();
         for (ChoiceNode choice : choices) {
             if (choice != null && choice.message != null && choice.message.content != null) {
-                allTags.addAll(TagList.of(choice.message.content));
+                String content = choice.message.content;
+
+                // Some models return lingering </think> tags in the output.
+                // I don't know why this happens.
+                // The same model might return a perfectly normal tag list 9 times in a row,
+                // and then give me a </think> in the middle of the list on the 10th try.
+                // We'll just trim them as we see it, and log it for debugging purposes.
+                if (content.contains("think>")) {
+                    log.warning("The model returned thinking data in the tag list - removed.");
+                }
+                content = content.replace("</think>", "").trim();
+                content = content.replace("<think>", "").trim(); // just in case (never seen this)
+
+                allTags.addAll(TagList.of(content));
             }
         }
         return allTags;

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
@@ -2,6 +2,7 @@ ext-iv-ice Release Notes
 Author: Steve Corbett
 
 Version 3.4.0 [TODO - release date]
+  #94 - Auto-tag: remove "thinking" data from some LLM models
   #91 - Auto-tag: add threshold option for image downscaling
   #89 - Auto-tag: make connect/request timeouts configurable
   #88 - Auto-tag: make system prompts configurable


### PR DESCRIPTION
This PR addresses issue #94 by working around a strange bug - some models erroneously (and intermittently) return `</think>` in the middle of a generated tag list. Added code to remove it if it happens, and log a warning.
