### PR TITLE
Issue #97 - Auto:tag add LogConsole integration and make warning configurable

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
@@ -234,7 +234,7 @@ public class IceExtension extends ImageViewerExtension implements UIReloadable {
                          .setHelpText("<html>Comma-separated list of tags.<br>" +
                                               "If specified, tag generation will be restricted to just these.<br>" +
                                               "Leave blank to let the LLM decide (results unpredictable!)</html>"));
-        list.add(new BooleanProperty(llmWarnNoTagsProp, "Log a warning if no tag restrictions", true)
+        list.add(new BooleanProperty(llmWarnNoTagsProp, "Log a warning if no tag restrictions are set", true)
                          .setHelpText(
                                  "<html>Logs a warning if you try to auto-tag an image without specifying any tags in the LLM tag list.<br>" +
                                          "This is because unrestricted tag generation can produce unpredictable or inconsistent results.<br>" +

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
@@ -5,6 +5,7 @@ import ca.corbett.extras.EnhancedAction;
 import ca.corbett.extras.LookAndFeelManager;
 import ca.corbett.extras.RedispatchingMouseAdapter;
 import ca.corbett.extras.io.KeyStrokeManager;
+import ca.corbett.extras.logging.LogConsoleStyle;
 import ca.corbett.extras.properties.AbstractProperty;
 import ca.corbett.extras.properties.BooleanProperty;
 import ca.corbett.extras.properties.ComboProperty;
@@ -18,6 +19,7 @@ import ca.corbett.extras.properties.ShortTextProperty;
 import ca.corbett.forms.fields.LongTextField;
 import ca.corbett.imageviewer.AppConfig;
 import ca.corbett.imageviewer.ImageOperation;
+import ca.corbett.imageviewer.LogConsoleManager;
 import ca.corbett.imageviewer.extensions.ImageViewerExtension;
 import ca.corbett.imageviewer.extensions.ice.actions.AutoTagAction;
 import ca.corbett.imageviewer.extensions.ice.actions.AutoTagBatchAction;
@@ -115,6 +117,7 @@ public class IceExtension extends ImageViewerExtension implements UIReloadable {
     public static final String llmUrlProp = "ICE.Auto-tag.url";
     public static final String llmDownscaleProp = "ICE.Auto-tag.downscaleForLLM";
     public static final String llmTagsProp = "ICE.Auto-tag.tags";
+    public static final String llmWarnNoTagsProp = "ICE.Auto-tag.warnIfNoTagRestrictions";
     public static final String autoTagKeyProp = "ICE.Auto-tag.autoTagHotKey";
     public static final String autoTagBatchKeyProp = "ICE.Auto-tag.autoTagBatchHotKey";
     public static final String sysPromptTaggedProp = "ICE.Auto-tag.sysPromptTagged";
@@ -231,6 +234,11 @@ public class IceExtension extends ImageViewerExtension implements UIReloadable {
                          .setHelpText("<html>Comma-separated list of tags.<br>" +
                                               "If specified, tag generation will be restricted to just these.<br>" +
                                               "Leave blank to let the LLM decide (results unpredictable!)</html>"));
+        list.add(new BooleanProperty(llmWarnNoTagsProp, "Log a warning if no tag restrictions", true)
+                         .setHelpText(
+                                 "<html>Logs a warning if you try to auto-tag an image without specifying any tags in the LLM tag list.<br>" +
+                                         "This is because unrestricted tag generation can produce unpredictable or inconsistent results.<br>" +
+                                         "Uncheck this option to disable the log warning.</html>"));
         list.add(new KeyStrokeProperty(autoTagKeyProp, "Auto-tag selected:",
                                        KeyStrokeManager.parseKeyStroke("F9"), // Why F9? I dunno.
                                        AutoTagAction.getInstance(requestTemplate))
@@ -313,6 +321,16 @@ public class IceExtension extends ImageViewerExtension implements UIReloadable {
         }
         quickTagPanels.clear();
         tagPreviewPanels.clear();
+    }
+
+    /**
+     * We override this to provide custom styles for the ImageViewer log console.
+     */
+    @Override
+    public List<LogConsoleStyle> getLogConsoleStyles() {
+        List<LogConsoleStyle> styles = new ArrayList<>();
+        styles.add(LogConsoleManager.createStyle("Auto-tag:", true, Color.MAGENTA, true));
+        return styles;
     }
 
     /**

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagAction.java
@@ -57,14 +57,15 @@ public class AutoTagAction extends EnhancedAction {
     public void actionPerformed(ActionEvent e) {
         ImageInstance currentImage = MainWindow.getInstance().getSelectedImage();
         if (currentImage.isEmpty()) {
-            MainWindow.getInstance().showMessageDialog(NAME, "Nothing selected.");
+            MainWindow.getInstance().showMessageDialog(NAME, "Auto-tag: Nothing selected.");
             return;
         }
 
         final File imageFile = currentImage.getImageFile();
         String filename = imageFile.getName().toLowerCase();
         if (!filename.endsWith(".jpg") && !filename.endsWith(".jpeg") && !filename.endsWith(".png")) {
-            MainWindow.getInstance().showMessageDialog(NAME, "Auto-tagging is only supported for JPEG and PNG images.");
+            MainWindow.getInstance()
+                      .showMessageDialog(NAME, "Auto-tag: this feature is only supported for JPEG and PNG images.");
             return;
         }
 
@@ -76,7 +77,7 @@ public class AutoTagAction extends EnhancedAction {
         // Make sure our config is good before proceeding:
         if (!aiManager.isFeatureEnabled()) {
             MainWindow.getInstance().showMessageDialog(NAME,
-                                                       "Auto-tag is not available because the LLM connection is not properly configured." +
+                                                       "Auto-tag: the feature not available because the LLM connection is not properly configured." +
                                                                "\nVisit the Auto-tag settings page in application properties to set it up.");
             return;
         }
@@ -121,7 +122,7 @@ public class AutoTagAction extends EnhancedAction {
             if (isEmpty) {
                 SwingUtilities.invokeLater(() -> {
                     MainWindow.getInstance().showMessageDialog(NAME,
-                                                               "The LLM had no tag suggestions for this image.");
+                                                               "Auto-tag: The LLM had no tag suggestions for this image.");
                 });
                 return;
             }
@@ -139,7 +140,7 @@ public class AutoTagAction extends EnhancedAction {
             String errorCode = error.getCode() == AiErrorBody.INTERNAL_ERROR ? "(Internal error)" : error.getCode() + "";
 
             // The request thread already logged the error, so we can just show a simple error message to the user.
-            String msg = "Failed to auto-tag image: "
+            String msg = "Auto-tag: Failed to auto-tag image!"
                     + "\n\nMessage:" + error.getMessage()
                     + "\nCode: " + errorCode
                     + "\nType: " + error.getType();

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagAction.java
@@ -77,7 +77,7 @@ public class AutoTagAction extends EnhancedAction {
         // Make sure our config is good before proceeding:
         if (!aiManager.isFeatureEnabled()) {
             MainWindow.getInstance().showMessageDialog(NAME,
-                                                       "Auto-tag: the feature not available because the LLM connection is not properly configured." +
+                                                       "Auto-tag: the feature is not available because the LLM connection is not properly configured." +
                                                                "\nVisit the Auto-tag settings page in application properties to set it up.");
             return;
         }

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagBatchAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagBatchAction.java
@@ -57,16 +57,15 @@ public class AutoTagBatchAction extends EnhancedAction {
         // add the menu item in file system mode, but let's be sure about it:
         if (MainWindow.getInstance().getBrowseMode() != MainWindow.BrowseMode.FILE_SYSTEM) {
             MainWindow.getInstance().showMessageDialog(NAME,
-                                                       "Auto-tag batch is only available in file system browse mode.");
+                                                       "Auto-tag: the batch tag feature is only available in file system browse mode.");
             return;
         }
 
-        // Make sure we have good LLM configuration before proceeding,
-        // and disable the "warn if no tag restrictions" option, as we will allow the user to override that anyway:
-        AiConnectionManager aiManager = new AiConnectionManager(requestTemplate, taggedPrompt, taglessPrompt, false);
+        // Make sure we have good LLM configuration before proceeding:
+        AiConnectionManager aiManager = new AiConnectionManager(requestTemplate, taggedPrompt, taglessPrompt);
         if (!aiManager.isFeatureEnabled()) {
             MainWindow.getInstance().showMessageDialog(NAME,
-                                                       "Auto-tag batch is not available because the LLM connection is not properly configured." +
+                                                       "Auto-tag: the batch tag feature is not available because the LLM connection is not properly configured." +
                                                                "\nVisit the Auto-tag settings page in application properties to set it up.");
             return;
         }

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiConnectionManager.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiConnectionManager.java
@@ -2,6 +2,7 @@ package ca.corbett.imageviewer.extensions.ice.llm;
 
 import ca.corbett.extras.progress.MultiProgressDialog;
 import ca.corbett.extras.properties.AbstractProperty;
+import ca.corbett.extras.properties.BooleanProperty;
 import ca.corbett.extras.properties.PasswordProperty;
 import ca.corbett.extras.properties.PropertiesManager;
 import ca.corbett.extras.properties.ShortTextProperty;
@@ -19,18 +20,6 @@ import java.util.logging.Logger;
 /**
  * Responsible for sending image analysis requests to a configured LLM for auto-tagging.
  * This is an experimental feature, and all of this is subject to change.
- * <p>
- * Some TODO items, in no particular order:
- * </p>
- * <ul>
- *     <li>Right now we're using template json from our jar resources and just search and replacing certain keys
- *         to form the request. This works, but is overly simplistic. We should probably use the openai-java
- *         library instead of forming raw REST requests ourselves.</li>
- * </ul>
- * <p>
- *     The above TODOs will be handled in future tickets, if the initial proof-of-concept works out.
- *     The current implementation is minimal.
- * </p>
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  */
@@ -56,7 +45,7 @@ public class AiConnectionManager {
     private String llmModel;
     private String llmApiKey;
     private TagList llmTags;
-    private final boolean warnUnrestricted;
+    private boolean warnUnrestricted;
 
     /**
      * If the LLM is unable to determine tags for some reason (the image is unclear, the given tag
@@ -73,30 +62,11 @@ public class AiConnectionManager {
 
     /**
      * You must specify the json request template, and both the "tagged" and "tagless" system prompts.
-     *
-     * @param requestTemplate The json template for the request body, with placeholders for prompt, model, image data, and tags. This is required.
-     * @param taggedPrompt    The system prompt to use when a restricted tag list is provided. This is required.
-     * @param taglessPrompt   The system prompt to use when no tag list is provided. This is required.
      */
     public AiConnectionManager(String requestTemplate, String taggedPrompt, String taglessPrompt) {
-        this(requestTemplate, taggedPrompt, taglessPrompt, true);
-    }
-
-    /**
-     * This constructor overload allows you to specify whether we should emit a warning if the user has not
-     * configured any tag restrictions. The default is true, but you can turn it off to avoid log noise if
-     * you are handling that case yourself.
-     *
-     * @param requestTemplate The json template for the request body, with placeholders for prompt, model, image data, and tags. This is required.
-     * @param taggedPrompt The system prompt to use when a restricted tag list is provided. This is required.
-     * @param taglessPrompt The system prompt to use when no tag list is provided. This is required.
-     * @param warnUnrestricted    Emits a log warning if no tag restrictions are set in application properties.
-     */
-    public AiConnectionManager(String requestTemplate, String taggedPrompt, String taglessPrompt, boolean warnUnrestricted) {
         this.requestTemplate = requestTemplate;
         this.taggedPrompt = taggedPrompt;
         this.taglessPrompt = taglessPrompt;
-        this.warnUnrestricted = warnUnrestricted;
 
         // We'll load this here in the constructor.
         // Our assumption is that this class is instantiated on demand, rather than keeping an instance around.
@@ -112,6 +82,10 @@ public class AiConnectionManager {
      */
     public boolean isFeatureEnabled() {
         return featureEnabled;
+    }
+
+    public boolean isWarnOnUnrestrictedTagList() {
+        return warnUnrestricted;
     }
 
     /**
@@ -235,6 +209,7 @@ public class AiConnectionManager {
         llmModel = null;
         llmApiKey = null;
         llmTags = null;
+        warnUnrestricted = true; // default to true, in case we can't find our prop
 
         // If the json template is null or blank, there's no point in continuing:
         if (requestTemplate == null || requestTemplate.isBlank()) {
@@ -327,15 +302,20 @@ public class AiConnectionManager {
             log.severe("LLM API key property is not a PasswordProperty - disabling LLM feature");
             return;
         }
+
+        // Look up the setting that decides if we should log a warning of LLM tags are empty:
+        prop = propsManager.getProperty(IceExtension.llmWarnNoTagsProp);
+        if (prop instanceof BooleanProperty warnProp) {
+            warnUnrestricted = warnProp.getValue();
+        }
+        else {
+            // Not fatal (though very weird). Just stick with the default value:
+            log.warning("LLM warnUnrestricted property is not a BooleanProperty - defaulting to true");
+        }
+
         prop = propsManager.getProperty(IceExtension.llmTagsProp);
         if (prop instanceof ShortTextProperty tagsProp) {
             llmTags = TagList.of(tagsProp.getValue()); // TagList can parse this for us
-            if (llmTags.isEmpty() && warnUnrestricted) {
-                // This may result in very unexpected behavior. Perhaps the user is unaware of the consequences here:
-                log.warning("LLM tags list is empty - the LLM will be free to choose any tags it wants!" +
-                                    " This may result in unpredictable or inconsistent tags being chosen. " +
-                                    "You can supply a tag list in configuration to restrict the LLM.");
-            }
         }
         else {
             log.severe("LLM tags property is not a ShortTextProperty - disabling LLM feature");

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiRequestThread.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiRequestThread.java
@@ -136,6 +136,15 @@ public class AiRequestThread extends SimpleProgressWorker {
                 return;
             }
 
+            // Log a nag warning if we have no LLM tag restrictions, since this may lead to unexpected results:
+            // (this can be disabled in the config if the user knows what they're doing)
+            if (tags.isEmpty() && manager.isWarnOnUnrestrictedTagList()) {
+                // This may result in very unexpected behavior. Perhaps the user is unaware of the consequences here:
+                log.warning("Auto-tag: the LLM tags list is empty - the LLM will be free to choose any tags it wants!" +
+                                    " This may result in unpredictable or inconsistent tags being chosen. " +
+                                    "You can supply a tag list in configuration to restrict the LLM.");
+            }
+
             // Do our tag substitution in our template to get the actual request body:
             String jsonBody = prepareRequestBody(model, tags, base64ImageData, mimeType);
 

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/AutoTagBatchDialog.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/AutoTagBatchDialog.java
@@ -171,14 +171,6 @@ public class AutoTagBatchDialog extends JDialog {
         }
         aiManager.setLlmTags(restrictionTags); // okay if empty - LLM will choose tags
 
-        // Emit a log warning if there are no tag restrictions:
-        if (aiManager.getLlmTags().isEmpty()) {
-            // This may result in very unexpected behavior. Perhaps the user is unaware of the consequences here:
-            log.warning("LLM tags list is empty - the LLM will be free to choose any tags it wants!" +
-                                " This may result in unpredictable or inconsistent tags being chosen. " +
-                                "You can supply a tag list in configuration to restrict the LLM.");
-        }
-
         // Set the flag to prevent concurrent batch operations:
         isOperationInProgress = true;
 

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
@@ -2,7 +2,7 @@ ext-iv-ice Release Notes
 Author: Steve Corbett
 
 Version 3.5.0 [TODO release date]
-  TODO release notes for 3.5.0
+  #97 - Auto-tag: LogConsole integration, configurable log warnings
 
 Version 3.4.0 [2026-05-18]
   #94 - Auto-tag: remove "thinking" data from some LLM models


### PR DESCRIPTION
This PR addresses issue #97 by improving logging for the Auto-tag feature:

- add a custom `LogConsoleStyle` for Auto-tag log messages, triggered by the fixed string `Auto-tag:`
- modified logging as needed to include that fixed string, to trigger our custom log style
- removed outdated TODO comment
- made the "no tag restrictions" log warning configurable, so the user can uncheck it to silence it entirely. Defaults to enabled.

