### PR TITLE
Issue #99 - Auto-tag: optionall include existing image tags

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
@@ -116,6 +116,7 @@ public class IceExtension extends ImageViewerExtension implements UIReloadable {
     public static final String llmModelProp = "ICE.Auto-tag.model";
     public static final String llmUrlProp = "ICE.Auto-tag.url";
     public static final String llmDownscaleProp = "ICE.Auto-tag.downscaleForLLM";
+    public static final String llmIncludeExisting = "ICE.Auto-tag.includeExistingTags";
     public static final String llmTagsProp = "ICE.Auto-tag.tags";
     public static final String llmWarnNoTagsProp = "ICE.Auto-tag.warnIfNoTagRestrictions";
     public static final String autoTagKeyProp = "ICE.Auto-tag.autoTagHotKey";
@@ -229,6 +230,10 @@ public class IceExtension extends ImageViewerExtension implements UIReloadable {
         list.add(new ShortTextProperty(llmModelProp, "LLM model name:", "gpt-3.5-turbo")
                          .setAllowBlank(true) // blank means not needed for this server
                          .setHelpText("<html>The name of the model to use for tag generation.</html>"));
+        list.add(new BooleanProperty(llmIncludeExisting, "Include existing tags in LLM prompt", false)
+                         .setHelpText(
+                                 "<html>If checked, the image's existing tags, if any, will be sent to the LLM when auto-tagging.<br>" +
+                                         "This might be useful to avoid redundant tags in some cases.</html>"));
         list.add(new ShortTextProperty(llmTagsProp, "LLM tag list:", "")
                          .setAllowBlank(true) // blank means the LLM will suggest tags without constraints
                          .setHelpText("<html>Comma-separated list of tags.<br>" +
@@ -782,6 +787,20 @@ public class IceExtension extends ImageViewerExtension implements UIReloadable {
         }
 
         return 60000; // default to 60 seconds if something goes wrong
+    }
+
+    /**
+     * Returns the currently-configured value of the "include existing tags in LLM prompt" option.
+     */
+    public static boolean getIncludeExistingTagsOption() {
+        // Look up our config prop:
+        PropertiesManager propsManager = AppConfig.getInstance().getPropertiesManager();
+        AbstractProperty prop = propsManager.getProperty(IceExtension.llmIncludeExisting);
+        if (prop instanceof BooleanProperty boolProp) {
+            return boolProp.getValue();
+        }
+
+        return false; // default to false if something goes wrong
     }
 
     /**

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiConnectionManager.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiConnectionManager.java
@@ -54,7 +54,8 @@ public class AiConnectionManager {
     public static final String NO_TAGS = "none";
 
     // Our search and replace keys for preparing our request json from templates:
-    public static final String KEY_PROMPT = "{{PROMPT}}";
+    public static final String KEY_SYS_PROMPT = "{{SYS_PROMPT}}";
+    public static final String KEY_USER_PROMPT = "{{USER_PROMPT}}";
     public static final String KEY_MODEL = "{{MODEL}}";
     public static final String KEY_IMG_DATA = "{{IMGDATA}}";
     public static final String KEY_TAGS = "{{TAGS}}";

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiRequestThread.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiRequestThread.java
@@ -7,6 +7,7 @@ import ca.corbett.imageviewer.extensions.ice.IceExtension;
 import ca.corbett.imageviewer.extensions.ice.TagList;
 import com.fasterxml.jackson.core.io.SerializedString;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.io.FilenameUtils;
 
 import javax.imageio.IIOImage;
 import javax.imageio.ImageIO;
@@ -52,8 +53,9 @@ public class AiRequestThread extends SimpleProgressWorker {
     private final AiConnectionManager.CompletionCallback onComplete;
     private final AiConnectionManager.ErrorCallback onError;
     private boolean chatty;
-    private long connectTimeoutMS;
-    private long requestTimeoutMS;
+    private final long connectTimeoutMS;
+    private final long requestTimeoutMS;
+    private final boolean includeExistingTags;
 
     public AiRequestThread(File imageFile,
                            AiConnectionManager manager,
@@ -65,9 +67,10 @@ public class AiRequestThread extends SimpleProgressWorker {
         this.imageFile = imageFile;
         chatty = true;
 
-        // Look up our timeout settings now, before the thread starts:
+        // Look up our config settings now, before the thread starts:
         connectTimeoutMS = IceExtension.getConnectTimeoutMS();
         requestTimeoutMS = IceExtension.getRequestTimeoutMS();
+        includeExistingTags = IceExtension.getIncludeExistingTagsOption();
     }
 
     /**
@@ -99,7 +102,11 @@ public class AiRequestThread extends SimpleProgressWorker {
             URL url = manager.getLlmUrl();
             String model = manager.getLlmModel();
             String apiKey = manager.getLlmApiKey();
-            TagList tags = manager.getLlmTags();
+            TagList llmTags = manager.getLlmTags();
+
+            // Load the existing tags for this image, if any:
+            TagList existingTags = TagList.fromFile(new File(imageFile.getParentFile(),
+                                                             FilenameUtils.getBaseName(imageFile.getName()) + ".ice"));
 
             // We'll start with the mime type of the original image:
             String base64ImageData;
@@ -138,7 +145,7 @@ public class AiRequestThread extends SimpleProgressWorker {
 
             // Log a nag warning if we have no LLM tag restrictions, since this may lead to unexpected results:
             // (this can be disabled in the config if the user knows what they're doing)
-            if (tags.isEmpty() && manager.isWarnOnUnrestrictedTagList()) {
+            if (llmTags.isEmpty() && manager.isWarnOnUnrestrictedTagList()) {
                 // This may result in very unexpected behavior. Perhaps the user is unaware of the consequences here:
                 log.warning("Auto-tag: the LLM tags list is empty - the LLM will be free to choose any tags it wants!" +
                                     " This may result in unpredictable or inconsistent tags being chosen. " +
@@ -146,7 +153,7 @@ public class AiRequestThread extends SimpleProgressWorker {
             }
 
             // Do our tag substitution in our template to get the actual request body:
-            String jsonBody = prepareRequestBody(model, tags, base64ImageData, mimeType);
+            String jsonBody = prepareRequestBody(model, llmTags, existingTags, base64ImageData, mimeType);
 
             // Now we can fire off the request and parse the response:
             try {
@@ -229,24 +236,40 @@ public class AiRequestThread extends SimpleProgressWorker {
         return badList;
     }
 
-    private String prepareRequestBody(String model, TagList tags, String base64ImageData, String mimeType) {
-        // Figure out which prompt we need:
-        String prompt = tags.isEmpty() ? manager.getTaglessPrompt() : manager.getTaggedPrompt();
+    private String prepareRequestBody(String model, TagList tags, TagList existingTags, String base64ImageData, String mimeType) {
+        // Figure out which system prompt we need:
+        String sysPrompt = tags.isEmpty() ? manager.getTaglessPrompt() : manager.getTaggedPrompt();
 
         // Handle safe escaping of our String inputs:
         // (things like embedded quotation marks or line breaks can cause problems for us.)
         // (note that we don't worry about the base64 image data, since it should already be json-safe.)
-        String safePrompt = new String(new SerializedString(prompt).asQuotedChars());
+        String safeSysPrompt = new String(new SerializedString(sysPrompt).asQuotedChars());
+        String safeUserPrompt = new String(new SerializedString(getUserPrompt(existingTags)).asQuotedChars());
         String safeModel = new String(new SerializedString(model).asQuotedChars());
         String safeTags = new String(new SerializedString(tags.toString()).asQuotedChars());
 
         // Now we can safely do our string replacement to get the final request body:
         return manager.getRequestTemplate()
-                      .replace(AiConnectionManager.KEY_PROMPT, safePrompt)
+                      .replace(AiConnectionManager.KEY_SYS_PROMPT, safeSysPrompt)
+                      .replace(AiConnectionManager.KEY_USER_PROMPT, safeUserPrompt)
                       .replace(AiConnectionManager.KEY_MODEL, safeModel)
                       .replace(AiConnectionManager.KEY_IMG_DATA, base64ImageData)
                       .replace(AiConnectionManager.KEY_TAGS, safeTags)
                       .replace(AiConnectionManager.KEY_MIME_TYPE, mimeType);
+    }
+
+    private String getUserPrompt(TagList existingTags) {
+        String userPrompt = "Please tag this image."; // simple prompt that defers entirely to the SYS_PROMPT.
+
+        if (includeExistingTags && !existingTags.isEmpty()) {
+            // Fancy prompt that tries to provide additional guidance based on what's already there:
+            userPrompt += " The existing tags for this image are: "
+                    + existingTags.toString() + ". "
+                    + "Only return tags if they are not already covered by the existing tags. "
+                    + "If the image is already adequately tagged, return the fixed string 'none'.";
+        }
+
+        return userPrompt;
     }
 
     /**

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiRequestThread.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiRequestThread.java
@@ -105,8 +105,9 @@ public class AiRequestThread extends SimpleProgressWorker {
             TagList llmTags = manager.getLlmTags();
 
             // Load the existing tags for this image, if any:
-            TagList existingTags = TagList.fromFile(new File(imageFile.getParentFile(),
-                                                             FilenameUtils.getBaseName(imageFile.getName()) + ".ice"));
+            // (but only if that option is enabled, to save ourselves some I/O on every image file if not):
+            File tagFile = new File(imageFile.getParentFile(), FilenameUtils.getBaseName(imageFile.getName()) + ".ice");
+            TagList existingTags = includeExistingTags ? TagList.fromFile(tagFile) : new TagList();
 
             // We'll start with the mime type of the original image:
             String base64ImageData;

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
@@ -2,6 +2,7 @@ ext-iv-ice Release Notes
 Author: Steve Corbett
 
 Version 3.5.0 [TODO release date]
+  #99 - Auto-tag: optionally supply existing tags to the LLM
   #98 - Auto-tag: add configurable pause in batch mode
   #97 - Auto-tag: LogConsole integration, configurable log warnings
 

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/llm/request_template.json
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/llm/request_template.json
@@ -3,14 +3,14 @@
   "messages": [
     {
       "role": "system",
-      "content": "{{PROMPT}}"
+      "content": "{{SYS_PROMPT}}"
     },
     {
       "role": "user",
       "content": [
         {
           "type": "text",
-          "text": "Please tag this image"
+          "text": "{{USER_PROMPT}}"
         },
         {
           "type": "image_url",


### PR DESCRIPTION
This PR addresses issue #99 by adding the option to include existing image tags when requesting auto-tagging from an LLM. Additional instructions are supplied to the LLM to only return tags if they are not already covered by the existing tags. 

This option is disabled by default, to match the previous behavior.