### PR TITLE
Issue #72 - persistence layer rewrite for tag index

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/TagIndex.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/TagIndex.java
@@ -4,6 +4,7 @@ import ca.corbett.extras.properties.AbstractProperty;
 import ca.corbett.extras.properties.BooleanProperty;
 import ca.corbett.imageviewer.AppConfig;
 import ca.corbett.imageviewer.Version;
+import ca.corbett.imageviewer.extensions.ice.io.TagIndexMigration;
 import ca.corbett.imageviewer.extensions.ice.io.TagIndexPersistence;
 import ca.corbett.imageviewer.extensions.ice.threads.ScanThread;
 
@@ -57,10 +58,12 @@ public class TagIndex {
 
     private static TagIndex instance;
     private File indexFile;
+    private File legacyIndexFile;
     private final Map<String, TagIndexEntry> indexEntries;
 
     protected TagIndex() {
-        indexFile = new File(Version.SETTINGS_DIR, "tagIndex.ice");
+        indexFile = new File(Version.SETTINGS_DIR, "tagIndex.db");
+        legacyIndexFile = new File(Version.SETTINGS_DIR, "tagIndex.ice");
         indexEntries = new HashMap<>();
     }
 
@@ -124,15 +127,17 @@ public class TagIndex {
     /**
      * Package-protected setter for unit tests.
      * Allows tests to specify a different persistence location to avoid overwriting
-     * the actual tagIndex.ice file on the machine running the tests.
+     * the actual tagIndex.db file on the machine running the tests.
      *
-     * @param file The file to use for persistence.
+     * @param file The file to use for SQLite persistence.
      */
     void setIndexFile(File file) {
         if (file.getParentFile() != null && !file.getParentFile().exists()) {
             file.getParentFile().mkdirs();
         }
         indexFile = file;
+        // Derive legacy file path from the same directory with the .ice extension
+        legacyIndexFile = new File(file.getParentFile(), "tagIndex.ice");
     }
 
     /**
@@ -233,6 +238,15 @@ public class TagIndex {
         indexEntries.clear();
     }
 
+    /**
+     * Loads the tag index from the SQLite database, performing migration from
+     * legacy format if needed. The migration decision flow:
+     * <ol>
+     * <li>If SQLite DB exists, load from SQLite directly.</li>
+     * <li>If SQLite DB does not exist but legacy .ice file exists, run one-time migration.</li>
+     * <li>If neither exists, log and return (no entries).</li>
+     * </ol>
+     */
     public void load() {
         // Hmm, I think the load should happen even if the tag index is disabled.
         // I mean, if it exists, let's load it up so it's ready to go if indexing is later enabled.
@@ -241,21 +255,43 @@ public class TagIndex {
         //    return;
         //}
 
-        if (! indexFile.exists()) {
-            log.info("IceExtension: tag index file not found.");
+        // Check if SQLite DB exists
+        if (indexFile.exists()) {
+            try {
+                List<TagIndexEntry> entries = TagIndexPersistence.loadSqlite(indexFile);
+                clear();
+                for (TagIndexEntry entry : entries) {
+                    indexEntries.put(entry.getImageFile().getAbsolutePath(), entry);
+                }
+                log.info("IceExtension: loaded " + indexEntries.size() + " entries from SQLite tag index.");
+            }
+            catch (IOException | UncheckedIOException ioe) {
+                log.log(Level.SEVERE, "TagIndex: problem reading SQLite tag index: " + ioe.getMessage(), ioe);
+            }
             return;
         }
 
-        try {
-            List<TagIndexEntry> entries = TagIndexPersistence.load(indexFile); // auto-detects file version
-            clear(); // after we read the file but before we start processing it
-            for (TagIndexEntry entry : entries) {
-                indexEntries.put(entry.getImageFile().getAbsolutePath(), entry);
+        // SQLite DB doesn't exist - check for legacy file
+        if (legacyIndexFile.exists()) {
+            try {
+                log.info("IceExtension: SQLite tag index not found, migrating from legacy format...");
+                TagIndexMigration.migrate(legacyIndexFile, indexFile);
+                // After migration, load from SQLite
+                List<TagIndexEntry> entries = TagIndexPersistence.loadSqlite(indexFile);
+                clear();
+                for (TagIndexEntry entry : entries) {
+                    indexEntries.put(entry.getImageFile().getAbsolutePath(), entry);
+                }
+                log.info(
+                        "IceExtension: migration complete, loaded " + indexEntries.size() + " entries from SQLite tag index.");
             }
+            catch (IOException | UncheckedIOException ioe) {
+                log.log(Level.SEVERE, "TagIndex: migration or load failed: " + ioe.getMessage(), ioe);
+            }
+            return;
         }
-        catch (IOException | UncheckedIOException ioe) {
-            log.log(Level.SEVERE, "TagIndex: problem reading tag index: "+ioe.getMessage(), ioe);
-        }
+
+        log.info("IceExtension: tag index file not found.");
     }
 
     public void save() {

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/io/TagIndexMigration.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/io/TagIndexMigration.java
@@ -40,10 +40,15 @@ public class TagIndexMigration {
      *   <li>Bulk insert all entries into SQLite in a single transaction</li>
      *   <li>Rename legacy file to .migrated only after full success</li>
      * </ol>
+     * <p>
+     * If the final rename to the {@value #MIGRATED_SUFFIX} file fails, the migration is still
+     * considered successful because the data has already been persisted to SQLite; in that case,
+     * a warning is logged and the legacy file is left in place for manual cleanup.
+     * </p>
      *
      * @param legacyFile The legacy pipe-separated index file (e.g., tagIndex.ice).
      * @param dbFile     The target SQLite database file path (e.g., tagIndex.db).
-     * @throws IOException if parsing, inserting, or renaming fails.
+     * @throws IOException if the legacy file does not exist, or if parsing or inserting fails.
      */
     public static void migrate(File legacyFile, File dbFile) throws IOException {
         if (!legacyFile.exists()) {

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/io/TagIndexMigration.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/io/TagIndexMigration.java
@@ -1,0 +1,71 @@
+package ca.corbett.imageviewer.extensions.ice.io;
+
+import ca.corbett.imageviewer.extensions.ice.TagIndexEntry;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Encapsulates one-time migration from legacy pipe-separated index files to SQLite.
+ * <p>
+ * The migration process:
+ * </p>
+ * <ol>
+ * <li>Parse legacy index file using existing TagIndexPersistence logic.</li>
+ * <li>Bulk insert migrated entries into SQLite in a single transaction.</li>
+ * <li>Rename legacy file to .migrated only after successful commit.</li>
+ * </ol>
+ * <p>
+ * If migration fails, the legacy file is left untouched for retry/inspection.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ * @since ICE 3.5.0
+ */
+public class TagIndexMigration {
+
+    private static final Logger log = Logger.getLogger(TagIndexMigration.class.getName());
+
+    private static final String MIGRATED_SUFFIX = ".migrated";
+
+    /**
+     * Performs one-time migration from a legacy index file to SQLite.
+     * <p>
+     * Steps:
+     * <ol>
+     *   <li>Parse legacy index file using existing TagIndexPersistence.load()</li>
+     *   <li>Bulk insert all entries into SQLite in a single transaction</li>
+     *   <li>Rename legacy file to .migrated only after full success</li>
+     * </ol>
+     *
+     * @param legacyFile The legacy pipe-separated index file (e.g., tagIndex.ice).
+     * @param dbFile     The target SQLite database file path (e.g., tagIndex.db).
+     * @throws IOException if parsing, inserting, or renaming fails.
+     */
+    public static void migrate(File legacyFile, File dbFile) throws IOException {
+        if (!legacyFile.exists()) {
+            throw new IOException("Legacy index file does not exist: " + legacyFile.getAbsolutePath());
+        }
+
+        // Step 1: Parse legacy index file
+        List<TagIndexEntry> entries = TagIndexPersistence.load(legacyFile);
+        log.info("IceExtension: parsed " + entries.size() + " entries from legacy index file.");
+
+        // Step 2: Bulk insert into SQLite
+        TagIndexPersistence.save(entries, dbFile);
+        log.info("IceExtension: inserted " + entries.size() + " entries into SQLite database.");
+
+        // Step 3: Rename legacy file only after successful commit
+        File migratedFile = new File(legacyFile.getParentFile(), legacyFile.getName() + MIGRATED_SUFFIX);
+        if (!legacyFile.renameTo(migratedFile)) {
+            // If rename fails, log but don't throw - the data is safely in SQLite
+            log.log(Level.WARNING, "IceExtension: could not rename legacy index file to " + migratedFile.getAbsolutePath()
+                    + ". Please rename manually: " + legacyFile.getAbsolutePath());
+        } else {
+            log.info("IceExtension: legacy index file renamed to " + migratedFile.getAbsolutePath());
+        }
+    }
+}

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/io/TagIndexPersistence.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/io/TagIndexPersistence.java
@@ -82,7 +82,8 @@ public class TagIndexPersistence {
     private static final String SQL_DELETE_ALL = "DELETE FROM tag_index";
 
     private static final String SQL_LOAD_ALL =
-            "SELECT image_path, tag_file_path, tag_file_size, tag_file_last_modified, tags FROM tag_index";
+            "SELECT image_path, tag_file_path, tag_file_size, tag_file_last_modified, tags FROM tag_index " +
+                    "ORDER BY image_path";
 
     // Connection pool / singleton
     private static Connection connection;

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/io/TagIndexPersistence.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/io/TagIndexPersistence.java
@@ -1,20 +1,23 @@
 package ca.corbett.imageviewer.extensions.ice.io;
 
-import ca.corbett.imageviewer.Version;
 import ca.corbett.imageviewer.extensions.ice.IceExtension;
 import ca.corbett.imageviewer.extensions.ice.TagIndexEntry;
 import ca.corbett.imageviewer.extensions.ice.TagList;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 
-import javax.swing.text.html.HTML;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +29,23 @@ import java.util.stream.Stream;
 /**
  * Handles saving and loading of the TagIndex to keep this logic in once place and
  * to keep the rest of the code isolated from the details of how the index is stored.
+ * <p>
+ * In its current form, persistence is backed by SQLite. Legacy text-file loading
+ * methods are retained only for migration purposes.
+ * </p>
+ * <p>
+ *     <b>BRIEF PERSISTENCE VERSION HISTORY</b>
+ * </p>
+ * <ul>
+ *     <li><b>v2.2.0</b>: initial implementation using a custom pipe-separated text format.
+ *     This format was simple but inefficient, as it repeated the parent directory path for every entry.</li>
+ *     <li><b>v2.2.1</b>: upgraded the pipe-separated format to be much more disk-space efficient.
+ *     Also added a header line to report the version of the format, to handle compatibility.</li>
+ *     <li><b>v3.5.0</b>: deprecated the pipe-separated format and added support for SQLite. The legacy loading/saving
+ *     methods are retained for migration purposes, but they are no longer used by the main code path.
+ *     The main load/save methods now use SQLite exclusively. The SQLite approach allows much more efficient
+ *     storage and faster load/save times, especially for large indexes.</li>
+ * </ul>
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  * @since ICE 2.2.1
@@ -35,6 +55,90 @@ public class TagIndexPersistence {
     private static final Logger log = Logger.getLogger(TagIndexPersistence.class.getName());
 
     private static final String HEADER = "ICE_tag_index";
+
+    // SQLite schema
+    private static final String SCHEMA_CREATE_TAG_INDEX =
+            "CREATE TABLE IF NOT EXISTS tag_index (" +
+                    "image_path TEXT PRIMARY KEY, " +
+                    "tag_file_path TEXT NOT NULL, " +
+                    "tag_file_size INTEGER NOT NULL, " +
+                    "tag_file_last_modified INTEGER NOT NULL, " +
+                    "tags TEXT NOT NULL)";
+
+    private static final String SCHEMA_CREATE_METADATA =
+            "CREATE TABLE IF NOT EXISTS metadata (" +
+                    "schema_version TEXT PRIMARY KEY NOT NULL)";
+
+    private static final String SCHEMA_VERSION_INSERT =
+            "INSERT INTO metadata (schema_version) VALUES ('3.5') " +
+                    "ON CONFLICT(schema_version) DO UPDATE SET schema_version = '3.5'";
+
+    // Prepared statements for tag_index operations
+    private static final String SQL_INSERT_ENTRY =
+            "INSERT INTO tag_index (image_path, tag_file_path, tag_file_size, tag_file_last_modified, tags) " +
+                    "VALUES (?, ?, ?, ?, ?)";
+
+    private static final String SQL_DELETE_ALL = "DELETE FROM tag_index";
+
+    private static final String SQL_LOAD_ALL =
+            "SELECT image_path, tag_file_path, tag_file_size, tag_file_last_modified, tags FROM tag_index";
+
+    // Connection pool / singleton
+    private static Connection connection;
+
+    /**
+     * Returns the active SQLite connection, creating one if necessary.
+     * Uses WAL mode for better concurrency characteristics.
+     * If the requested DB file differs from the current connection, the old connection is closed first.
+     */
+    private static Connection getDbConnection(File dbFile) throws SQLException {
+        String newUrl = "jdbc:sqlite:" + dbFile.getAbsolutePath();
+        if (connection != null && !connection.isClosed()) {
+            String currentUrl = connection.getMetaData().getURL();
+            if (newUrl.equals(currentUrl)) {
+                return connection;
+            }
+            // Different DB file - close old connection
+            connection.close();
+            connection = null;
+        }
+        connection = DriverManager.getConnection(newUrl);
+        // Enable WAL mode for better concurrent read/write characteristics
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("PRAGMA journal_mode=WAL");
+        }
+        return connection;
+    }
+
+    /**
+     * Closes the active SQLite connection. Used for cleanup (e.g., tests).
+     */
+    public static void closeConnection() {
+        if (connection != null) {
+            try {
+                connection.close();
+            }
+            catch (SQLException e) {
+                log.log(Level.WARNING, "Failed to close SQLite connection", e);
+            }
+            connection = null;
+        }
+    }
+
+    /**
+     * Initializes the SQLite database schema.
+     */
+    private static void initSchema(File dbFile) throws SQLException {
+        Connection conn = getDbConnection(dbFile);
+        try (Statement stmt = conn.createStatement()) {
+            stmt.execute(SCHEMA_CREATE_TAG_INDEX);
+            stmt.execute(SCHEMA_CREATE_METADATA);
+        }
+        // Insert schema version if not already present
+        try (PreparedStatement ps = conn.prepareStatement(SCHEMA_VERSION_INSERT)) {
+            ps.executeUpdate();
+        }
+    }
 
     /**
      * Reports what version of the extension was used to create the given tag index file.
@@ -63,9 +167,89 @@ public class TagIndexPersistence {
     }
 
     /**
-     * Saves the given list of TagIndexEntry instances to the given tag index file.
+     * Saves the given list of TagIndexEntry instances to the given SQLite tag index file.
+     * Uses a single transaction: DELETE all existing entries, then bulk INSERT new entries.
      */
-    public static void save(List<TagIndexEntry> indexEntries, File tagIndexFile) throws IOException {
+    public static void save(List<TagIndexEntry> indexEntries, File dbFile) throws IOException {
+        try {
+            initSchema(dbFile);
+            Connection conn = getDbConnection(dbFile);
+
+            try {
+                conn.setAutoCommit(false);
+                try (PreparedStatement deletePs = conn.prepareStatement(SQL_DELETE_ALL);
+                     PreparedStatement insertPs = conn.prepareStatement(SQL_INSERT_ENTRY)) {
+
+                    // Clear existing data
+                    deletePs.executeUpdate();
+
+                    // Bulk insert new entries
+                    for (TagIndexEntry entry : indexEntries) {
+                        insertPs.setString(1, entry.getImageFile().getAbsolutePath());
+                        insertPs.setString(2, entry.getTagFile().getAbsolutePath());
+                        insertPs.setLong(3, entry.getTagFileSize());
+                        insertPs.setLong(4, entry.getTagFileLastModified());
+                        insertPs.setString(5, entry.getTagList().toString());
+                        insertPs.addBatch();
+                    }
+                    insertPs.executeBatch();
+                }
+                conn.commit();
+            }
+            catch (SQLException e) {
+                conn.rollback();
+                throw new IOException("Failed to save tag index to SQLite: " + e.getMessage(), e);
+            }
+            finally {
+                conn.setAutoCommit(true);
+            }
+        }
+        catch (SQLException e) {
+            throw new IOException("Failed to initialize SQLite schema: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Loads all entries from the SQLite database at the given path.
+     */
+    public static List<TagIndexEntry> loadSqlite(File dbFile) throws IOException {
+        List<TagIndexEntry> entries = new ArrayList<>();
+        try {
+            initSchema(dbFile);
+            Connection conn = getDbConnection(dbFile);
+            try (PreparedStatement ps = conn.prepareStatement(SQL_LOAD_ALL);
+                 ResultSet rs = ps.executeQuery()) {
+
+                while (rs.next()) {
+                    TagIndexEntry entry = new TagIndexEntry();
+
+                    String imagePath = rs.getString("image_path");
+                    String tagFilePath = rs.getString("tag_file_path");
+                    long tagFileSize = rs.getLong("tag_file_size");
+                    long tagFileLastModified = rs.getLong("tag_file_last_modified");
+                    String tagsStr = rs.getString("tags");
+
+                    entry.setImageFile(new File(imagePath));
+                    entry.setTagFile(new File(tagFilePath));
+                    entry.setTagFileSize(tagFileSize);
+                    entry.setTagFileLastModified(tagFileLastModified);
+                    entry.setTagList(TagList.of(tagsStr));
+
+                    entries.add(entry);
+                }
+            }
+        }
+        catch (SQLException e) {
+            throw new IOException("Failed to load tag index from SQLite: " + e.getMessage(), e);
+        }
+        return entries;
+    }
+
+    /**
+     * Saves the given list of TagIndexEntry instances to the given tag index file
+     * (legacy pipe-separated format).
+     */
+    public static void saveLegacy(List<TagIndexEntry> indexEntries, File tagIndexFile) throws IOException {
         List<String> lines = new ArrayList<>(1000);
         lines.add(HEADER + "|" + IceExtension.extInfo.getVersion());
 
@@ -99,7 +283,7 @@ public class TagIndexPersistence {
             lines.add(line);
         }
 
-        // Save it in one shot (... do we REALLY want to build out the whole thing in memory first?):
+        // Save it in one shot:
         FileUtils.writeLines(tagIndexFile, lines);
     }
 
@@ -163,6 +347,11 @@ public class TagIndexPersistence {
     /**
      * Loads a tag index file using the current save format. This format is used as of the 2.2.1
      * release, and is much more efficient with disk space.
+     * <p>
+     *     As of v3.5, the name of this method is wrong, because the pipe-separated format is
+     *     now officially a legacy format. But, we'll keep these legacy methods for a release or two,
+     *     until the migration effort is done, and then they can just be deleted.
+     * </p>
      */
     private static List<TagIndexEntry> loadCurrentFormat(File tagIndexFile) throws IOException {
         Map<Integer, String> locationMap = new HashMap<>(1000);

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/io/TagIndexPersistence.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/io/TagIndexPersistence.java
@@ -67,11 +67,12 @@ public class TagIndexPersistence {
 
     private static final String SCHEMA_CREATE_METADATA =
             "CREATE TABLE IF NOT EXISTS metadata (" +
-                    "schema_version TEXT PRIMARY KEY NOT NULL)";
+                    "id INTEGER PRIMARY KEY NOT NULL CHECK (id = 1), " +
+                    "schema_version TEXT NOT NULL)";
 
     private static final String SCHEMA_VERSION_INSERT =
-            "INSERT INTO metadata (schema_version) VALUES ('3.5') " +
-                    "ON CONFLICT(schema_version) DO UPDATE SET schema_version = '3.5'";
+            "INSERT INTO metadata (id, schema_version) VALUES (1, '3.5') " +
+                    "ON CONFLICT(id) DO UPDATE SET schema_version = excluded.schema_version";
 
     // Prepared statements for tag_index operations
     private static final String SQL_INSERT_ENTRY =

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
@@ -5,6 +5,7 @@ Version 3.5.0 [TODO release date]
   #99 - Auto-tag: optionally supply existing tags to the LLM
   #98 - Auto-tag: add configurable pause in batch mode
   #97 - Auto-tag: LogConsole integration, configurable log warnings
+  #72 - Rewrite persistence layer to use SQLite instead of custom
 
 Version 3.4.0 [2026-05-18]
   #94 - Auto-tag: remove "thinking" data from some LLM models

--- a/src/test/java/ca/corbett/imageviewer/extensions/ice/TagIndexTest.java
+++ b/src/test/java/ca/corbett/imageviewer/extensions/ice/TagIndexTest.java
@@ -5,6 +5,8 @@ import ca.corbett.extras.io.FileSystemUtil;
 import ca.corbett.extras.properties.BooleanProperty;
 import ca.corbett.extras.properties.PropertiesManager;
 import ca.corbett.imageviewer.AppConfig;
+import ca.corbett.imageviewer.extensions.ice.io.TagIndexPersistence;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,14 +58,20 @@ class TagIndexTest {
                 .build();
     }
 
+    @AfterAll
+    public static void tearDownClass() {
+        // Clean up SQLite connection after all tests
+        TagIndexPersistence.closeConnection();
+    }
+
     @BeforeEach
     public void setUpTagIndex() {
         // Get a fresh instance for each test and inject our mocked AppConfig
         tagIndex = TagIndex.getInstance();
         tagIndex.setAppConfigProvider(() -> appConfig);
         
-        // Set index file to temp directory to avoid overwriting real tagIndex.ice
-        File tempIndexFile = new File(tempDir.toFile(), "tagIndex.ice");
+        // Set index file to temp directory to avoid overwriting real tagIndex.db
+        File tempIndexFile = new File(tempDir.toFile(), "tagIndex.db");
         tagIndex.setIndexFile(tempIndexFile);
         
         tagIndex.clear(); // Ensure clean state

--- a/src/test/java/ca/corbett/imageviewer/extensions/ice/io/TagIndexMigrationTest.java
+++ b/src/test/java/ca/corbett/imageviewer/extensions/ice/io/TagIndexMigrationTest.java
@@ -1,0 +1,165 @@
+package ca.corbett.imageviewer.extensions.ice.io;
+
+import ca.corbett.extensions.AppExtensionInfo;
+import ca.corbett.extras.io.FileSystemUtil;
+import ca.corbett.imageviewer.extensions.ice.IceExtension;
+import ca.corbett.imageviewer.extensions.ice.TagIndexEntry;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for TagIndexMigration.
+ */
+class TagIndexMigrationTest {
+
+    @TempDir
+    File tempDir;
+
+    @BeforeAll
+    public static void setup() {
+        IceExtension.extInfo = new AppExtensionInfo.Builder("Test")
+                .setVersion("2.2.1")
+                .build();
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        TagIndexPersistence.closeConnection();
+    }
+
+    @Test
+    public void migrate_currentFormat_legacyIce_shouldMigrateToSqlite() throws Exception {
+        // GIVEN a current-format (2.2.1) legacy index file
+        String legacyContent = """
+                ICE_tag_index|2.2.1
+                LOC|0|/tmp/test
+                0|test.jpg|100|5000|hello, world
+                """;
+        File legacyFile = new File(tempDir, "tagIndex.ice");
+        FileSystemUtil.writeStringToFile(legacyContent, legacyFile);
+        File dbFile = new File(tempDir, "tagIndex.db");
+        assertFalse(dbFile.exists());
+
+        // WHEN we migrate
+        TagIndexMigration.migrate(legacyFile, dbFile);
+
+        // THEN the DB should exist with the migrated entries
+        assertTrue(dbFile.exists());
+        List<TagIndexEntry> entries = TagIndexPersistence.loadSqlite(dbFile);
+        assertEquals(1, entries.size());
+        assertEquals("/tmp/test/test.jpg", entries.get(0).getImageFile().getAbsolutePath());
+        assertEquals("hello, world", entries.get(0).getTagList().toString());
+    }
+
+    @Test
+    public void migrate_legacy220Format_shouldMigrateToSqlite() throws Exception {
+        // GIVEN a legacy 2.2.0 format index file
+        String legacyContent = """
+                /tmp/test/image1.jpg|/tmp/test/image1.ice|30|0|foo,bar
+                /tmp/test/image2.jpg|/tmp/test/image2.ice|40|1|baz,qux
+                """;
+        File legacyFile = new File(tempDir, "tagIndex.ice");
+        FileSystemUtil.writeStringToFile(legacyContent, legacyFile);
+        File dbFile = new File(tempDir, "tagIndex.db");
+        assertFalse(dbFile.exists());
+
+        // WHEN we migrate
+        TagIndexMigration.migrate(legacyFile, dbFile);
+
+        // THEN the DB should exist with the migrated entries
+        assertTrue(dbFile.exists());
+        List<TagIndexEntry> entries = TagIndexPersistence.loadSqlite(dbFile);
+        assertEquals(2, entries.size());
+        assertEquals("/tmp/test/image1.jpg", entries.get(0).getImageFile().getAbsolutePath());
+        assertEquals("/tmp/test/image2.jpg", entries.get(1).getImageFile().getAbsolutePath());
+        assertEquals("foo, bar", entries.get(0).getTagList().toString());
+        assertEquals("baz, qux", entries.get(1).getTagList().toString());
+    }
+
+    @Test
+    public void migrate_withNonExistentLegacyFile_shouldThrow() throws Exception {
+        // GIVEN a non-existent legacy file
+        File legacyFile = new File(tempDir, "nonexistent.ice");
+        File dbFile = new File(tempDir, "tagIndex.db");
+
+        // WHEN we migrate
+        IOException exception = assertThrows(IOException.class, () ->
+                TagIndexMigration.migrate(legacyFile, dbFile));
+
+        // THEN it should report the file doesn't exist
+        assertTrue(exception.getMessage().contains("does not exist"));
+    }
+
+    @Test
+    public void migrate_successfulRename_createsMigratedFile() throws Exception {
+        // GIVEN a legacy file
+        String legacyContent = "ICE_tag_index|2.2.1\nLOC|0|/tmp\n0|img.jpg|0|0|\n";
+        File legacyFile = new File(tempDir, "tagIndex.ice");
+        FileSystemUtil.writeStringToFile(legacyContent, legacyFile);
+        File dbFile = new File(tempDir, "tagIndex.db");
+
+        // WHEN we migrate
+        TagIndexMigration.migrate(legacyFile, dbFile);
+
+        // THEN the legacy file should be renamed to .migrated
+        File migratedFile = new File(tempDir, "tagIndex.ice.migrated");
+        assertTrue(migratedFile.exists());
+        assertFalse(legacyFile.exists());
+    }
+
+    @Test
+    public void migrate_emptyLegacyFile_shouldCreateEmptySqlite() throws Exception {
+        // GIVEN an empty legacy file (header only)
+        String legacyContent = "ICE_tag_index|2.2.1\n";
+        File legacyFile = new File(tempDir, "tagIndex.ice");
+        FileSystemUtil.writeStringToFile(legacyContent, legacyFile);
+        File dbFile = new File(tempDir, "tagIndex.db");
+
+        // WHEN we migrate
+        TagIndexMigration.migrate(legacyFile, dbFile);
+
+        // THEN the DB should exist with 0 entries
+        assertTrue(dbFile.exists());
+        List<TagIndexEntry> entries = TagIndexPersistence.loadSqlite(dbFile);
+        assertEquals(0, entries.size());
+    }
+
+    @Test
+    public void migrate_multipleEntries_shouldPreserveAllData() throws Exception {
+        // GIVEN a legacy file with many entries
+        StringBuilder legacyContent = new StringBuilder();
+        legacyContent.append("ICE_tag_index|2.2.1\n");
+        legacyContent.append("LOC|0|/tmp/migration\n");
+        for (int i = 0; i < 100; i++) {
+            legacyContent.append(String.format("0|image%d.jpg|%d|%d|tag1, tag2, tag3\n", i, 50 + i, 1000L * i));
+        }
+        File legacyFile = new File(tempDir, "tagIndex.ice");
+        FileSystemUtil.writeStringToFile(legacyContent.toString(), legacyFile);
+        File dbFile = new File(tempDir, "tagIndex.db");
+
+        // WHEN we migrate
+        TagIndexMigration.migrate(legacyFile, dbFile);
+
+        // THEN all entries should be present in the DB
+        assertTrue(dbFile.exists());
+        List<TagIndexEntry> entries = TagIndexPersistence.loadSqlite(dbFile);
+        assertEquals(100, entries.size());
+        // Spot-check a few entries
+        assertEquals("/tmp/migration/image0.jpg", entries.get(0).getImageFile().getAbsolutePath());
+        assertEquals(50, entries.get(0).getTagFileSize());
+        assertEquals(0, entries.get(0).getTagFileLastModified());
+        assertEquals("/tmp/migration/image99.jpg", entries.get(99).getImageFile().getAbsolutePath());
+        assertEquals(149, entries.get(99).getTagFileSize());
+    }
+}

--- a/src/test/java/ca/corbett/imageviewer/extensions/ice/io/TagIndexPersistenceTest.java
+++ b/src/test/java/ca/corbett/imageviewer/extensions/ice/io/TagIndexPersistenceTest.java
@@ -5,8 +5,10 @@ import ca.corbett.extras.io.FileSystemUtil;
 import ca.corbett.imageviewer.extensions.ice.IceExtension;
 import ca.corbett.imageviewer.extensions.ice.TagIndexEntry;
 import ca.corbett.imageviewer.extensions.ice.TagList;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -16,11 +18,20 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class TagIndexPersistenceTest {
 
+    @TempDir
+    File tempDir;
+
     @BeforeAll
     public static void setup() {
         IceExtension.extInfo = new AppExtensionInfo.Builder("Test")
                 .setVersion("2.2.1")
                 .build(); // cheesy, but we need it for these unit tests
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        // Clean up SQLite connection after all tests
+        TagIndexPersistence.closeConnection();
     }
 
     @Test
@@ -30,9 +41,8 @@ class TagIndexPersistenceTest {
                 /tmp/image1.jpg|/tmp/image1.ice|30|0|hello,there
                 /tmp/image2.jpg|/tmp/image2.ice|40|1|hello,again
                 """;
-        File indexFile = File.createTempFile("TagIndexTest", ".txt");
-        indexFile.deleteOnExit();
-        FileSystemUtil.writeStringToFile(tagIndex,indexFile);
+        File indexFile = new File(tempDir, "legacy.ice");
+        FileSystemUtil.writeStringToFile(tagIndex, indexFile);
 
         // WHEN we try to parse it:
         assertEquals("2.2.0", TagIndexPersistence.getIndexVersion(indexFile));
@@ -51,17 +61,86 @@ class TagIndexPersistenceTest {
     }
 
     @Test
-    public void saveLegacyFormat_withData_shouldSaveAndLoad() throws Exception {
+    public void saveCurrentFormat_withData_shouldSaveAndLoad() throws Exception {
         // GIVEN some tag index entries:
         List<TagIndexEntry> entries = new ArrayList<>();
         for (int i = 0; i < 5; i++) {
             entries.add(generateIndexEntry(i));
         }
 
-        // WHEN we save them and then load them back:
-        File indexFile = File.createTempFile("TagIndexTest", ".txt");
-        indexFile.deleteOnExit();
-        TagIndexPersistence.save(entries, indexFile);
+        // WHEN we save them to SQLite and then load them back:
+        File dbFile = new File(tempDir, "tagIndex.db");
+        TagIndexPersistence.save(entries, dbFile);
+        entries = TagIndexPersistence.loadSqlite(dbFile);
+
+        // THEN we should see our entries:
+        assertEquals(5, entries.size());
+        for (int i = 0; i < 5; i++) {
+            validateIndexEntry(entries.get(i), i);
+        }
+    }
+
+    @Test
+    public void sqlite_saveAndLoad_withEmptyList_shouldSucceed() throws Exception {
+        // GIVEN an empty list of entries
+        List<TagIndexEntry> entries = new ArrayList<>();
+
+        // WHEN we save and load
+        File dbFile = new File(tempDir, "empty.db");
+        TagIndexPersistence.save(entries, dbFile);
+        entries = TagIndexPersistence.loadSqlite(dbFile);
+
+        // THEN we should see 0 entries
+        assertEquals(0, entries.size());
+    }
+
+    @Test
+    public void sqlite_saveTwice_shouldReplaceAllEntries() throws Exception {
+        // GIVEN some initial entries
+        List<TagIndexEntry> entries1 = new ArrayList<>();
+        entries1.add(generateIndexEntry(0));
+        entries1.add(generateIndexEntry(1));
+
+        File dbFile = new File(tempDir, "replace.db");
+        TagIndexPersistence.save(entries1, dbFile);
+
+        // WHEN we save a different set of entries
+        List<TagIndexEntry> entries2 = new ArrayList<>();
+        entries2.add(generateIndexEntry(2));
+
+        TagIndexPersistence.save(entries2, dbFile);
+        entries2 = TagIndexPersistence.loadSqlite(dbFile);
+
+        // THEN we should only see the second set
+        assertEquals(1, entries2.size());
+        assertEquals("/tmp/image2.jpg", entries2.get(0).getImageFile().getAbsolutePath());
+    }
+
+    @Test
+    public void sqlite_schemaInitialized_onFirstLoad() throws Exception {
+        // GIVEN a SQLite database path that doesn't exist yet
+        File dbFile = new File(tempDir, "new.db");
+        assertFalse(dbFile.exists());
+
+        // WHEN we load from it
+        List<TagIndexEntry> entries = TagIndexPersistence.loadSqlite(dbFile);
+
+        // THEN the file should exist and contain 0 entries
+        assertTrue(dbFile.exists());
+        assertEquals(0, entries.size());
+    }
+
+    @Test
+    public void saveLegacy_withData_shouldSaveAndLoad() throws Exception {
+        // GIVEN some tag index entries:
+        List<TagIndexEntry> entries = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            entries.add(generateIndexEntry(i));
+        }
+
+        // WHEN we save them using legacy format and then load them back:
+        File indexFile = new File(tempDir, "legacy.ice");
+        TagIndexPersistence.saveLegacy(entries, indexFile);
         entries = TagIndexPersistence.load(indexFile);
 
         // THEN we should see our entries:


### PR DESCRIPTION
This PR addresses issue #72 by deprecating the custom pipe-separated persistence format for the tag index, and replacing it with SQLite support. A one-time automatic migration will be performed at startup, with the old tag index file being renamed and preserved instead of deleted. 

Issue #72 suggested supporting both the legacy format and the newer SQLite database, but I made an executive decision to deprecate the old format and remove it from the main code path, to lower the maintenance burden. After a release or two, the legacy persistence methods and associated tests can be removed entirely.