### PR TITLE
Issue #105 - allow auto-tag batch mode in image set browse mode

### DIFF
--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/IceExtension.java
@@ -434,12 +434,8 @@ public class IceExtension extends ImageViewerExtension implements UIReloadable {
             }
 
             // Auto-tag menu items:
-            actions.add(AutoTagAction.getInstance(requestTemplate));
-            if (browseMode == MainWindow.BrowseMode.FILE_SYSTEM) {
-                // Batch mode only available if we're browsing directories:
-                // (though it would be a neat feature to batch-tag all images in an image set... maybe later)
-                actions.add(AutoTagBatchAction.getInstance(requestTemplate));
-            }
+            actions.add(AutoTagAction.getInstance(requestTemplate)); // tag single image
+            actions.add(AutoTagBatchAction.getInstance(requestTemplate)); // batch mode
         }
 
         return actions;

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagBatchAction.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/actions/AutoTagBatchAction.java
@@ -4,6 +4,7 @@ import ca.corbett.extras.EnhancedAction;
 import ca.corbett.imageviewer.extensions.ice.llm.AiConnectionManager;
 import ca.corbett.imageviewer.extensions.ice.ui.dialogs.AutoTagBatchDialog;
 import ca.corbett.imageviewer.ui.MainWindow;
+import ca.corbett.imageviewer.ui.imagesets.ImageSet;
 
 import java.awt.event.ActionEvent;
 import java.io.File;
@@ -47,29 +48,33 @@ public class AutoTagBatchAction extends EnhancedAction {
 
     @Override
     public void actionPerformed(ActionEvent e) {
-        File dir = MainWindow.getInstance().getCurrentDirectory();
-        if (dir == null) {
-            MainWindow.getInstance().showMessageDialog(NAME, "Nothing selected.");
-            return;
-        }
-
-        // Shouldn't be possible to launch this action in image set mode, because we only
-        // add the menu item in file system mode, but let's be sure about it:
-        if (MainWindow.getInstance().getBrowseMode() != MainWindow.BrowseMode.FILE_SYSTEM) {
-            MainWindow.getInstance().showMessageDialog(NAME,
-                                                       "Auto-tag: the batch tag feature is only available in file system browse mode.");
-            return;
-        }
-
-        // Make sure we have good LLM configuration before proceeding:
+        // We need to have a good LLM configuration before proceeding:
         AiConnectionManager aiManager = new AiConnectionManager(requestTemplate, taggedPrompt, taglessPrompt);
         if (!aiManager.isFeatureEnabled()) {
-            MainWindow.getInstance().showMessageDialog(NAME,
-                                                       "Auto-tag: the batch tag feature is not available because the LLM connection is not properly configured." +
-                                                               "\nVisit the Auto-tag settings page in application properties to set it up.");
+            String msg = "Auto-tag: the batch tag feature is not available because the LLM connection is not properly configured." +
+                    "\nVisit the Auto-tag settings page in application properties to set it up.";
+            MainWindow.getInstance().showMessageDialog(NAME, msg);
             return;
         }
 
-        new AutoTagBatchDialog(MainWindow.getInstance(), dir, aiManager).setVisible(true);
+        // If we're in filesystem mode, we need a directory to operate on:
+        if (MainWindow.getInstance().getBrowseMode() == MainWindow.BrowseMode.FILE_SYSTEM) {
+            File dir = MainWindow.getInstance().getCurrentDirectory();
+            if (dir == null) {
+                MainWindow.getInstance().showMessageDialog(NAME, "Nothing selected.");
+                return;
+            }
+            new AutoTagBatchDialog(MainWindow.getInstance(), dir, aiManager).setVisible(true);
+        }
+
+        // Otherwise, we need an ImageSet to operate on:
+        else {
+            ImageSet imageSet = MainWindow.getInstance().getImageSetPanel().getSelectedImageSet().orElse(null);
+            if (imageSet == null) {
+                MainWindow.getInstance().showMessageDialog(NAME, "Nothing selected.");
+                return;
+            }
+            new AutoTagBatchDialog(MainWindow.getInstance(), imageSet, aiManager).setVisible(true);
+        }
     }
 }

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiRequestThread.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiRequestThread.java
@@ -53,7 +53,7 @@ public class AiRequestThread extends SimpleProgressWorker {
     private final AiConnectionManager.CompletionCallback onComplete;
     private final AiConnectionManager.ErrorCallback onError;
     private boolean chatty;
-    private int responseCode = 200;
+    private int responseCode = -1;
     private final long connectTimeoutMS;
     private final long requestTimeoutMS;
     private final boolean includeExistingTags;
@@ -90,7 +90,7 @@ public class AiRequestThread extends SimpleProgressWorker {
     }
 
     /**
-     * Returns the HTTP response code from the LLM request, or 200 if the request has not completed yet.
+     * Returns the HTTP response code from the LLM request, or -1 if no response has been received yet.
      */
     public int getResponseCode() {
         return responseCode;
@@ -104,7 +104,7 @@ public class AiRequestThread extends SimpleProgressWorker {
         //    2) base64 encode the image
         //    3) make the request
         fireProgressBegins(3);
-        this.responseCode = 200; // innocent until proven guilty
+        this.responseCode = -1; // begin with a sentinel value to distinguish "not yet received" from actual responses
         try {
 
             // These were validated by our AiManager, so we won't do it here again:
@@ -185,7 +185,7 @@ public class AiRequestThread extends SimpleProgressWorker {
                 ObjectMapper objectMapper = new ObjectMapper();
 
                 this.responseCode = response.statusCode(); // save this for later retrieval
-                if (response.statusCode() != 200) {
+                if (response.statusCode() < 200 || response.statusCode() > 299) {
                     try {
                         // We can try to parse out what happened:
                         AiErrorBody errorBody = objectMapper.readValue(response.body(), AiErrorBody.class);

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiRequestThread.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/llm/AiRequestThread.java
@@ -53,6 +53,7 @@ public class AiRequestThread extends SimpleProgressWorker {
     private final AiConnectionManager.CompletionCallback onComplete;
     private final AiConnectionManager.ErrorCallback onError;
     private boolean chatty;
+    private int responseCode = 200;
     private final long connectTimeoutMS;
     private final long requestTimeoutMS;
     private final boolean includeExistingTags;
@@ -88,6 +89,13 @@ public class AiRequestThread extends SimpleProgressWorker {
         this.chatty = chatty;
     }
 
+    /**
+     * Returns the HTTP response code from the LLM request, or 200 if the request has not completed yet.
+     */
+    public int getResponseCode() {
+        return responseCode;
+    }
+
     @Override
     public void run() {
         // Let's get the progress bar up:
@@ -96,6 +104,7 @@ public class AiRequestThread extends SimpleProgressWorker {
         //    2) base64 encode the image
         //    3) make the request
         fireProgressBegins(3);
+        this.responseCode = 200; // innocent until proven guilty
         try {
 
             // These were validated by our AiManager, so we won't do it here again:
@@ -175,6 +184,7 @@ public class AiRequestThread extends SimpleProgressWorker {
                 HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
                 ObjectMapper objectMapper = new ObjectMapper();
 
+                this.responseCode = response.statusCode(); // save this for later retrieval
                 if (response.statusCode() != 200) {
                     try {
                         // We can try to parse out what happened:

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/AutoTagBatchDialog.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/AutoTagBatchDialog.java
@@ -79,7 +79,7 @@ public class AutoTagBatchDialog extends JDialog {
     private BatchWorker batchWorker;
 
     /**
-     * Creates a BatchTagDialog suitable for image set mode.
+     * Creates an AutoTagBatchTagDialog suitable for image set mode.
      * In this mode, the given ImageSet will be auto-tagged.
      *
      * @param owner     The parent frame for this dialog.
@@ -91,7 +91,7 @@ public class AutoTagBatchDialog extends JDialog {
     }
 
     /**
-     * Creates a BatchTagDialog suitable for file system mode.
+     * Creates an AutoTagBatchTagDialog suitable for file system mode.
      * In this mode, the given directory will be scanned for eligible images, and those images will be auto-tagged.
      * The user will be presented with an option for whether to include subdirectories in the scan.
      *

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/AutoTagBatchDialog.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/AutoTagBatchDialog.java
@@ -114,6 +114,9 @@ public class AutoTagBatchDialog extends JDialog {
      */
     AutoTagBatchDialog(Frame owner, File dir, ImageSet imageSet, AiConnectionManager aiManager) {
         super(owner, NAME, true);
+        if (aiManager == null) {
+            throw new IllegalArgumentException("aiManager must be provided.");
+        }
         if (dir == null && imageSet == null) {
             throw new IllegalArgumentException("Either dir or imageSet must be provided.");
         }

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/AutoTagBatchDialog.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/AutoTagBatchDialog.java
@@ -436,6 +436,16 @@ public class AutoTagBatchDialog extends JDialog {
                     thread.setChatty(false); // quiet, you!
                     thread.run(); // run the request synchronously in this worker thread, so we can track progress and handle errors appropriately
 
+                    int code = thread.getResponseCode();
+                    if (code >= 500 && code <= 599) {
+                        // Executive decision: if we hit any kind of server error, abort the whole batch:
+                        // (debatable, but our assumption is that this is not recoverable and also not
+                        //  specific to this one image... it's more likely a bad API key or a server outage,
+                        //  or a local server that was accidentally started without mmproj or whatever)
+                        // Our error handler has already displayed the details, so we can just bail out:
+                        throw new Exception("Aborting batch after response code " + code); // will be handled below
+                    }
+
                     // If this isn't the last image, let's pause (if so configured):
                     // (this configurable pause is intended to help avoid rate-limiting on some servers)
                     boolean wasCanceled = false;

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/AutoTagBatchDialog.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/AutoTagBatchDialog.java
@@ -20,6 +20,7 @@ import ca.corbett.imageviewer.extensions.ice.llm.AiConnectionManager;
 import ca.corbett.imageviewer.extensions.ice.llm.AiErrorBody;
 import ca.corbett.imageviewer.extensions.ice.llm.AiRequestThread;
 import ca.corbett.imageviewer.ui.MainWindow;
+import ca.corbett.imageviewer.ui.imagesets.ImageSet;
 import org.apache.commons.io.FilenameUtils;
 
 import javax.swing.BorderFactory;
@@ -36,12 +37,14 @@ import java.awt.event.WindowEvent;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
 
 /**
- * Shows a dialog that allows auto-tagging of all jpeg and/or png images in the selected
- * directory, with optional recursion. This feature is experimental and subject to change!
+ * Shows a dialog that allows auto-tagging of all jpeg and/or png images either in
+ * a given directory (with optional recursion), or in a provided ImageSet.
+ * This feature is experimental and subject to change!
  * <p>
  * Note that batch auto-tagging, unlike single-image auto-tagging, will automatically update
  * the affected image(s) with the suggested tags, with no opportunity to review or edit them.
@@ -63,9 +66,10 @@ public class AutoTagBatchDialog extends JDialog {
     private static final String NAME = "Auto-tag batch";
 
     private final AiConnectionManager aiManager;
-    private final File dir;
+    private final File dir; // null if we're in image set mode
+    private final ImageSet imageSet; // null if we're in file system mode
     private final List<File> eligibleImages = new ArrayList<>();
-    private final CheckBoxField recursiveField;
+    private final CheckBoxField recursiveField; // ignored in image set mode
     private final LabelField imageCountLabel;
     private final CheckBoxField useConfigRestrictionField;
     private final ShortTextField tagRestrictionField;
@@ -73,13 +77,55 @@ public class AutoTagBatchDialog extends JDialog {
     private boolean isOperationInProgress;
     private BatchWorker batchWorker;
 
+    /**
+     * Creates a BatchTagDialog suitable for image set mode.
+     * In this mode, the given ImageSet will be auto-tagged.
+     *
+     * @param owner     The parent frame for this dialog.
+     * @param imageSet  The ImageSet to be auto-tagged. Must not be null.
+     * @param aiManager The AiConnectionManager to use for making requests to the LLM server. Must not be null.
+     */
+    public AutoTagBatchDialog(Frame owner, ImageSet imageSet, AiConnectionManager aiManager) {
+        this(owner, null, imageSet, aiManager);
+    }
+
+    /**
+     * Creates a BatchTagDialog suitable for file system mode.
+     * In this mode, the given directory will be scanned for eligible images, and those images will be auto-tagged.
+     * The user will be presented with an option for whether to include subdirectories in the scan.
+     *
+     * @param owner     The parent frame for this dialog.
+     * @param dir       The directory to be scanned for eligible images. Must not be null.
+     * @param aiManager The AiConnectionManager to use for making requests to the LLM server. Must not be null.
+     */
     public AutoTagBatchDialog(Frame owner, File dir, AiConnectionManager aiManager) {
+        this(owner, dir, null, aiManager);
+    }
+
+    /**
+     * Used internally by the two public constructors. Exactly one of dir or imageSet must be non-null.
+     * This determines which mode the dialog operates in (file system vs image set).
+     *
+     * @param owner     The parent frame for this dialog.
+     * @param dir       The directory to be scanned for eligible images. Must be non-null if imageSet is null.
+     * @param imageSet  The ImageSet to be auto-tagged. Must be non-null if dir is null.
+     * @param aiManager The AiConnectionManager to use for making requests to the LLM server. Must not be null.
+     */
+    AutoTagBatchDialog(Frame owner, File dir, ImageSet imageSet, AiConnectionManager aiManager) {
         super(owner, NAME, true);
+        if (dir == null && imageSet == null) {
+            throw new IllegalArgumentException("Either dir or imageSet must be provided.");
+        }
+        if (dir != null && imageSet != null) {
+            throw new IllegalArgumentException("Only one of dir or imageSet can be provided.");
+        }
         this.dir = dir;
+        this.imageSet = imageSet;
         this.aiManager = aiManager;
         batchWorker = null;
         recursiveField = new CheckBoxField("Include subdirectories", true);
         recursiveField.addValueChangedListener(e -> rescan());
+        recursiveField.setVisible(dir != null); // irrelevant in image set mode, so hide it
         imageCountLabel = new LabelField("Image count:", "0");
         imageCountLabel.setHelpText("Note: Only JPEG and PNG images are counted here.");
         tagRestrictionField = new ShortTextField("Tag restriction", 20);
@@ -133,6 +179,23 @@ public class AutoTagBatchDialog extends JDialog {
      * be considerable, so we should give them a heads-up in advance.
      */
     private void rescan() {
+        // In image set mode, we don't need a scan worker, we can just
+        // count up all eligible images directly in this thread:
+        if (imageSet != null) {
+            eligibleImages.clear();
+            for (String imageFilePath : imageSet.getImageFilePaths()) {
+                String filename = imageFilePath.toLowerCase(Locale.ROOT);
+                if (!filename.endsWith(".jpg") && !filename.endsWith(".jpeg") && !filename.endsWith(".png")) {
+                    continue; // skip ineligible file types
+                }
+                eligibleImages.add(new File(imageFilePath));
+            }
+            imageCountLabel.setText(String.valueOf(eligibleImages.size()));
+            return;
+        }
+
+        // In file system mode, things are a bit harder.
+        // First, we need a valid directory:
         if (dir == null || !dir.isDirectory()) {
             log.warning("No directory selected.");
             return;
@@ -159,8 +222,10 @@ public class AutoTagBatchDialog extends JDialog {
     private void doBatch() {
         // Quick sanity check: if we have no images, there's nothing we can do here:
         if (eligibleImages.isEmpty()) {
-            MainWindow.getInstance().showMessageDialog(NAME,
-                                                       "No eligible images found in the selected directory.");
+            String message = dir != null
+                    ? "No eligible images found in the selected directory."
+                    : "No eligible images found in the selected image set.";
+            MainWindow.getInstance().showMessageDialog(NAME, message);
             log.info("No eligible images found, aborting batch auto-tag.");
             return;
         }
@@ -208,7 +273,10 @@ public class AutoTagBatchDialog extends JDialog {
         JButton button = new JButton("Rescan");
         button.setPreferredSize(new Dimension(100, 25));
         button.addActionListener(e -> rescan());
-        buttonPanel.add(button);
+        if (dir != null) {
+            // This button only makes sense in filesystem mode
+            buttonPanel.add(button);
+        }
 
         button = new JButton("Auto-tag!");
         button.setPreferredSize(new Dimension(100, 25));
@@ -338,10 +406,6 @@ public class AutoTagBatchDialog extends JDialog {
                                                                    "\nError type: " + error.getType() +
                                                                    "\n\nAborting batch operation.");
             });
-
-            // We can break out of the loop here, which will cause the batch operation to end.
-            // The isOperationInProgress flag will be reset in the finally block, allowing the user to try again if they want.
-            throw new RuntimeException("Batch auto-tagging aborted due to error.");
         }
 
         @Override

--- a/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/AutoTagBatchDialog.java
+++ b/src/main/java/ca/corbett/imageviewer/extensions/ice/ui/dialogs/AutoTagBatchDialog.java
@@ -49,12 +49,13 @@ import java.util.logging.Logger;
  * Note that batch auto-tagging, unlike single-image auto-tagging, will automatically update
  * the affected image(s) with the suggested tags, with no opportunity to review or edit them.
  * This is a bit of a YOLO option, especially if you have not constrained the LLM with
- * a restricted tag list. If any auto-tag request fails, the batch is aborted. Tags that
- * have already been applied at that point in the operation have already been saved.
+ * a restricted tag list. If any auto-tag request fails with a 5xx error response,
+ * the batch is aborted. Other error types will attempt to continue with the rest of the batch.
+ * </p>
+ * <p>
+ * If the batch is aborted or canceled partway through, tags that have already been applied
+ * up to that point in the operation have already been committed to disk.
  * (There is no "transaction rollback" option here... maybe a future feature).
- * Same thing applies if the batch operation is canceled - all tags that have already
- * been received from the LLM at that point are already saved. "Cancel" just stops
- * the operation from proceeding any further.
  * </p>
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
@@ -397,14 +398,18 @@ public class AutoTagBatchDialog extends JDialog {
             log.severe("Auto-tag operation failed: " + error.getMessage()
                                + " (code: " + error.getCode() + ", type: " + error.getType() + ")");
 
-            // If any request fails, we will abort the entire batch and show an error message to the user.
+            // Show error details to the user on the EDT:
             SwingUtilities.invokeLater(() -> {
+                String addendum = "";
+                if (error.getCode() >= 500 && error.getCode() <= 599) {
+                    addendum = "\n\nAborting batch operation.";
+                }
                 MainWindow.getInstance().showMessageDialog(NAME,
                                                            "Error auto-tagging image: " + imageFile.getName() +
                                                                    "\nError code: " + error.getCode() +
                                                                    "\nMessage: " + error.getMessage() +
                                                                    "\nError type: " + error.getType() +
-                                                                   "\n\nAborting batch operation.");
+                                                                   addendum);
             });
         }
 

--- a/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
+++ b/src/main/resources/ca/corbett/imageviewer/extensions/ice/ReleaseNotes.txt
@@ -2,6 +2,7 @@ ext-iv-ice Release Notes
 Author: Steve Corbett
 
 Version 3.5.0 [TODO release date]
+  #105 - Auto-tag: add support for batch mode in image set mode
   #99 - Auto-tag: optionally supply existing tags to the LLM
   #98 - Auto-tag: add configurable pause in batch mode
   #97 - Auto-tag: LogConsole integration, configurable log warnings


### PR DESCRIPTION
This PR addresses issue #105 by allowing auto-tag "batch" mode when browsing in image set mode. Previously, the code insisted on having a currently-selected filesystem directory before proceeding with a batch auto-tag operation. Now, the code will also allow a batch operation if an ImageSet is selected.

Unrelated to this change, improved error handling during batch operations. Abort the batch if a `5xx` response is received from the server, on the assumption that it is not recoverable and also not specific to the input image. All other error types will continue the batch operation with the next image.